### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: main
+    branches: master
   pull_request:
     branches: '*'
 

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -2,10 +2,10 @@ name: Check Release
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
 
 permissions:
   contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+<!-- <START NEW CHANGELOG ENTRY> -->
+
+<!-- <END NEW CHANGELOG ENTRY> -->

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,5 @@
 include LICENSE
-include README.md
-include RELEASE.md
+include *.md
 include pyproject.toml
 
 include package.json


### PR DESCRIPTION
Similar to #13, so we get CI to run on this repo on the default branch.

Alternatively, it would also be fine to rename the default branch to `main`. If so then we can discard this PR.