### PR TITLE
Add LSP to the Binder image

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -19,3 +19,4 @@ dependencies:
   - wheel
   # additional packages for demos
   # - ipywidgets
+  - jupyterlab-lsp

--- a/binder/overrides.json
+++ b/binder/overrides.json
@@ -1,0 +1,5 @@
+{
+  "@krassowski/jupyterlab-lsp:completion": {
+    "layout": "detail-below"
+  }
+}

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -42,6 +42,9 @@ _("jupyter", "server", "extension", "list")
 # initially list installed extensions to determine if there are any surprises
 _("jupyter", "labextension", "list")
 
+# install javascript language server for autocompletion and error highlighting
+_("jlpm", "add", "javascript-typescript-langserver")
+
 
 print("JupyterLab with @jupyterlab/plugin-playground is ready to run with:\n")
 print("\tjupyter lab\n")

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -43,7 +43,7 @@ _("jupyter", "server", "extension", "list")
 _("jupyter", "labextension", "list")
 
 # install javascript language server for autocompletion and error highlighting
-_("jlpm", "add", "javascript-typescript-langserver")
+_("jlpm", "add", "typescript-language-server")
 
 
 print("JupyterLab with @jupyterlab/plugin-playground is ready to run with:\n")

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -44,7 +44,8 @@ _("jupyter", "server", "extension", "list")
 _("jupyter", "labextension", "list")
 
 # install javascript language server for autocompletion and error highlighting
-_("jlpm", "add", "typescript-language-server")
+# (typescript-language-server depends on tsutils which requires us to choose typescript version)
+_("jlpm", "add", "typescript-language-server", "typescript@4.1")
 
 # add overrides for LSP settings
 SETTINGS = Path(sys.prefix) / "share/jupyter/lab/settings"

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -8,6 +8,7 @@
 
         python3 binder/postBuild
 """
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -45,6 +46,10 @@ _("jupyter", "labextension", "list")
 # install javascript language server for autocompletion and error highlighting
 _("jlpm", "add", "typescript-language-server")
 
+# add overrides for LSP settings
+SETTINGS = Path(sys.prefix) / "share/jupyter/lab/settings"
+SETTINGS.mkdir(parents=True, exist_ok=True)
+shutil.copy2("binder/overrides.json", SETTINGS / "overrides.json")
 
 print("JupyterLab with @jupyterlab/plugin-playground is ready to run with:\n")
 print("\tjupyter lab\n")


### PR DESCRIPTION
Closes #24.

Binder: https://mybinder.org/v2/gh/krassowski/jupyterlab-plugin-playground/add-lsp?urlpath=lab

![Screenshot from 2021-10-24 14-21-40](https://user-images.githubusercontent.com/5832902/138596108-d42df841-569b-4085-9dc4-7885607bbf01.png)

Note: we can hold this while I investigate migrating to a newer server (https://github.com/jupyter-lsp/jupyterlab-lsp/pull/697) and we could improve the default theme of the completer so that the detail is shown below the label not next to it (so it is not as spread out).