### PR TITLE
Automated Changelog Entry for 0.4.0 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,30 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.4.0
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab-plugin-playground/compare/v0.3.0...d2927797381a74fc731f2e929302e9ae328bece6))
+
+### Enhancements made
+
+- Transpile (optional) TypeScript, support imports (package and relative) and schema [#28](https://github.com/jupyterlab/jupyterlab-plugin-playground/pull/28) ([@krassowski](https://github.com/krassowski))
+- Add LSP to the Binder image [#26](https://github.com/jupyterlab/jupyterlab-plugin-playground/pull/26) ([@krassowski](https://github.com/krassowski))
+
+### Maintenance and upkeep improvements
+
+- Use `maintainer-tools` actions [#32](https://github.com/jupyterlab/jupyterlab-plugin-playground/pull/32) ([@jtpio](https://github.com/jtpio))
+- Bump nanoid from 3.1.29 to 3.2.0 [#31](https://github.com/jupyterlab/jupyterlab-plugin-playground/pull/31) ([@dependabot](https://github.com/dependabot))
+- Fix CI [#17](https://github.com/jupyterlab/jupyterlab-plugin-playground/pull/17) ([@jtpio](https://github.com/jtpio))
+
+### Other merged PRs
+
+- Use title case in label [#23](https://github.com/jupyterlab/jupyterlab-plugin-playground/pull/23) ([@krassowski](https://github.com/krassowski))
+- Fix example in readme [#19](https://github.com/jupyterlab/jupyterlab-plugin-playground/pull/19) ([@jasongrout](https://github.com/jasongrout))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab-plugin-playground/graphs/contributors?from=2021-10-15&to=2022-03-24&type=c))
+
+[@dependabot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab-plugin-playground+involves%3Adependabot+updated%3A2021-10-15..2022-03-24&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab-plugin-playground+involves%3Ajasongrout+updated%3A2021-10-15..2022-03-24&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab-plugin-playground+involves%3Ajtpio+updated%3A2021-10-15..2022-03-24&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab-plugin-playground+involves%3Akrassowski+updated%3A2021-10-15..2022-03-24&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab-plugin-playground+involves%3Awelcome+updated%3A2021-10-15..2022-03-24&type=Issues)
+
 <!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.4.0 on master

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab-plugin-playground  |
| Branch  | master  |
| Version Spec | 0.4.0 |
| Since | v0.3.0 |