### PR TITLE
Rename default branch to `main`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: master
+    branches: main
   pull_request:
     branches: '*'
 

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -2,10 +2,10 @@ name: Check Release
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # JupyterLab Plugin Playground
 
 [![Github Actions Status](https://github.com/jupyterlab/jupyterlab-plugin-playground/workflows/Build/badge.svg)](https://github.com/jupyterlab/jupyterlab-plugin-playground/actions/workflows/build.yml)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlab/jupyterlab-plugin-playground/master?urlpath=lab)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlab/jupyterlab-plugin-playground/main?urlpath=lab)
 
 A JupyterLab extension to write and load simple JupyterLab plugins inside JupyterLab.
 


### PR DESCRIPTION
The default branch has been renamed to `main`.

This updates the references in CI workflows and the README.