### PR TITLE
Use async imports, add `cell-toolbar` and `collaboration` plugins

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ dist
 coverage
 **/*.d.ts
 tests
+src/modules.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ node_modules
 **/lib
 **/package.json
 jupyterlab_plugin_playground
+src/modules.ts

--- a/package.json
+++ b/package.json
@@ -52,12 +52,14 @@
     "@jupyterlab/apputils": "^3.0.0",
     "@jupyterlab/fileeditor": "^3.0.0",
     "@jupyterlab/settingregistry": "^3.0.0",
-    "requirejs": "^2.3.6",
     "raw-loader": "^4.0.2",
+    "requirejs": "^2.3.6",
     "typescript": "~4.1.3"
   },
   "devDependencies": {
     "@jupyterlab/builder": "^3.0.0",
+    "@jupyterlab/cell-toolbar": "^3.4.0",
+    "@jupyterlab/collaboration": "^3.5.0-beta.0",
     "@jupyterlab/completer": "^3.2.5",
     "@jupyterlab/console": "^3.2.5",
     "@jupyterlab/debugger": "^3.2.5",

--- a/scripts/modules.py
+++ b/scripts/modules.py
@@ -2,15 +2,6 @@ from jupyterlab.coreconfig import CoreConfig
 import jupyterlab
 
 
-def to_identifier(package_name: str):
-    return (
-        package_name
-        .replace('@', '')
-        .replace('-', '_')
-        .replace('/', '_')
-    )
-
-
 # packages not used in core, but required for examples
 EXTRA_MODULES = {
     '@jupyterlab/docregistry',
@@ -25,8 +16,6 @@ IGNORED_MODULES = {
 }
 
 TEMPLATE = """\
-{imports_string}
-
 export const modules = {{
   {key_map_string}
 }};
@@ -38,18 +27,13 @@ def create_modules_map(core_modules, extra_modules, ignored_modules):
         *core_modules,
         *extra_modules
     } - set(ignored_modules))
-    imports = [
-        f"import * as {to_identifier(module)} from '{module}';"
-        for module in modules_to_export
-    ]
 
     key_map = [
-        f"'{module}': {to_identifier(module)}"
+        f"'{module}': import('{module}') as any"
         for module in modules_to_export
     ]
 
     modules_dot_ts = TEMPLATE.format(
-        imports_string='\n'.join(imports),
         key_map_string=',\n  '.join(key_map)
     )
     return modules_dot_ts

--- a/scripts/modules.py
+++ b/scripts/modules.py
@@ -16,8 +16,15 @@ IGNORED_MODULES = {
 }
 
 TEMPLATE = """\
-export const modules = {{
-  {key_map_string}
+import type {{ IModule }} from './types';
+
+
+export function loadKnownModule(name: string): Promise<IModule | null> {{
+  switch (name) {{
+    {key_map_string}
+    default:
+      return Promise.resolve(null);
+  }}
 }};
 """
 
@@ -29,12 +36,12 @@ def create_modules_map(core_modules, extra_modules, ignored_modules):
     } - set(ignored_modules))
 
     key_map = [
-        f"'{module}': import('{module}') as any"
+        f"case '{module}':\n      return import('{module}') as any;"
         for module in modules_to_export
     ]
 
     modules_dot_ts = TEMPLATE.format(
-        key_map_string=',\n  '.join(key_map)
+        key_map_string='\n    '.join(key_map)
     )
     return modules_dot_ts
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,12 +77,10 @@ class PluginPlayground {
     protected settings: ISettingRegistry.ISettings,
     protected requirejs: IRequireJS
   ) {
-    // Define the widgets base module for RequireJS (left for compatibility only)
-    requirejs.define(
-      '@jupyter-widgets/base',
-      [],
-      () => modules['@jupyter-widgets/base']
-    );
+    modules['@jupyter-widgets/base'].then((module: any) => {
+      // Define the widgets base module for RequireJS (left for compatibility only)
+      requirejs.define('@jupyter-widgets/base', [], () => module);
+    });
 
     app.commands.addCommand(CommandIDs.loadCurrentAsExtension, {
       label: 'Load Current File As Extension',
@@ -179,7 +177,7 @@ class PluginPlayground {
       tokenMap.get('jupyter.extensions.jupyterWidgetRegistry')
     );
     const importResolver = new ImportResolver({
-      modules: modules as unknown as Record<string, IModule>,
+      modules: modules as unknown as Record<string, Promise<IModule>>,
       tokenMap: tokenMap,
       requirejs: this.requirejs,
       settings: this.settings,

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,13 @@ class PluginPlayground {
           });
         if (widget) {
           widget.content.ready.then(() => {
-            widget.content.model.value.text = PLUGIN_TEMPLATE;
+            if (typeof widget.content.model.value !== 'undefined') {
+              // JupyterLab 3.x
+              widget.content.model.value.text = PLUGIN_TEMPLATE;
+            } else {
+              // JupyterLab 4.x
+              widget.content.model.sharedModel.setSource(PLUGIN_TEMPLATE);
+            }
           });
         }
         return widget;

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,15 +29,13 @@ import { PluginLoader, PluginLoadingError } from './loader';
 
 import { PluginTranspiler } from './transpiler';
 
-import { modules } from './modules';
+import { loadKnownModule } from './modules';
 
 import { formatErrorWithResult } from './errors';
 
 import { ImportResolver } from './resolver';
 
 import { IRequireJS, RequireJSLoader } from './requirejs';
-
-import { IModule } from './types';
 
 namespace CommandIDs {
   export const createNewFile = 'plugin-playground:create-new-plugin';
@@ -77,7 +75,7 @@ class PluginPlayground {
     protected settings: ISettingRegistry.ISettings,
     protected requirejs: IRequireJS
   ) {
-    modules['@jupyter-widgets/base'].then((module: any) => {
+    loadKnownModule('@jupyter-widgets/base').then((module: any) => {
       // Define the widgets base module for RequireJS (left for compatibility only)
       requirejs.define('@jupyter-widgets/base', [], () => module);
     });
@@ -177,7 +175,7 @@ class PluginPlayground {
       tokenMap.get('jupyter.extensions.jupyterWidgetRegistry')
     );
     const importResolver = new ImportResolver({
-      modules: modules as unknown as Record<string, Promise<IModule>>,
+      loadKnownModule: loadKnownModule,
       tokenMap: tokenMap,
       requirejs: this.requirejs,
       settings: this.settings,

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,11 +169,15 @@ class PluginPlayground {
   }
 
   private async _loadPlugin(code: string, path: string | null) {
+    const app = this.app as any;
+    // `_serviceMap` in Lumino 1.x (JupyterLab 3.x), `_services` in Lumino 2.x (JupyterLab 4.0)
+    const serviceTokens =
+      typeof app._serviceMap !== 'undefined'
+        ? app._serviceMap.keys()
+        : app._services.keys();
+
     const tokenMap = new Map(
-      Array.from((this.app as any)._serviceMap.keys()).map((t: any) => [
-        t.name,
-        t
-      ])
+      Array.from(serviceTokens).map((t: any) => [t.name, t])
     );
     // Widget registry does not follow convention of importName:tokenName
     tokenMap.set(

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -1,56 +1,115 @@
-export const modules = {
-  '@jupyter-widgets/base': import('@jupyter-widgets/base') as any,
-  '@jupyterlab/application': import('@jupyterlab/application') as any,
-  '@jupyterlab/apputils': import('@jupyterlab/apputils') as any,
-  '@jupyterlab/cell-toolbar': import('@jupyterlab/cell-toolbar') as any,
-  '@jupyterlab/codeeditor': import('@jupyterlab/codeeditor') as any,
-  '@jupyterlab/codemirror': import('@jupyterlab/codemirror') as any,
-  '@jupyterlab/collaboration': import('@jupyterlab/collaboration') as any,
-  '@jupyterlab/completer': import('@jupyterlab/completer') as any,
-  '@jupyterlab/console': import('@jupyterlab/console') as any,
-  '@jupyterlab/coreutils': import('@jupyterlab/coreutils') as any,
-  '@jupyterlab/debugger': import('@jupyterlab/debugger') as any,
-  '@jupyterlab/docmanager': import('@jupyterlab/docmanager') as any,
-  '@jupyterlab/docprovider': import('@jupyterlab/docprovider') as any,
-  '@jupyterlab/docregistry': import('@jupyterlab/docregistry') as any,
-  '@jupyterlab/documentsearch': import('@jupyterlab/documentsearch') as any,
-  '@jupyterlab/extensionmanager': import('@jupyterlab/extensionmanager') as any,
-  '@jupyterlab/filebrowser': import('@jupyterlab/filebrowser') as any,
-  '@jupyterlab/fileeditor': import('@jupyterlab/fileeditor') as any,
-  '@jupyterlab/imageviewer': import('@jupyterlab/imageviewer') as any,
-  '@jupyterlab/inspector': import('@jupyterlab/inspector') as any,
-  '@jupyterlab/launcher': import('@jupyterlab/launcher') as any,
-  '@jupyterlab/logconsole': import('@jupyterlab/logconsole') as any,
-  '@jupyterlab/mainmenu': import('@jupyterlab/mainmenu') as any,
-  '@jupyterlab/markdownviewer': import('@jupyterlab/markdownviewer') as any,
-  '@jupyterlab/notebook': import('@jupyterlab/notebook') as any,
-  '@jupyterlab/outputarea': import('@jupyterlab/outputarea') as any,
-  '@jupyterlab/rendermime': import('@jupyterlab/rendermime') as any,
-  '@jupyterlab/rendermime-interfaces': import('@jupyterlab/rendermime-interfaces') as any,
-  '@jupyterlab/services': import('@jupyterlab/services') as any,
-  '@jupyterlab/settingeditor': import('@jupyterlab/settingeditor') as any,
-  '@jupyterlab/settingregistry': import('@jupyterlab/settingregistry') as any,
-  '@jupyterlab/shared-models': import('@jupyterlab/shared-models') as any,
-  '@jupyterlab/statedb': import('@jupyterlab/statedb') as any,
-  '@jupyterlab/statusbar': import('@jupyterlab/statusbar') as any,
-  '@jupyterlab/terminal': import('@jupyterlab/terminal') as any,
-  '@jupyterlab/toc': import('@jupyterlab/toc') as any,
-  '@jupyterlab/tooltip': import('@jupyterlab/tooltip') as any,
-  '@jupyterlab/translation': import('@jupyterlab/translation') as any,
-  '@jupyterlab/ui-components': import('@jupyterlab/ui-components') as any,
-  '@lumino/algorithm': import('@lumino/algorithm') as any,
-  '@lumino/application': import('@lumino/application') as any,
-  '@lumino/commands': import('@lumino/commands') as any,
-  '@lumino/coreutils': import('@lumino/coreutils') as any,
-  '@lumino/datagrid': import('@lumino/datagrid') as any,
-  '@lumino/disposable': import('@lumino/disposable') as any,
-  '@lumino/domutils': import('@lumino/domutils') as any,
-  '@lumino/dragdrop': import('@lumino/dragdrop') as any,
-  '@lumino/messaging': import('@lumino/messaging') as any,
-  '@lumino/properties': import('@lumino/properties') as any,
-  '@lumino/signaling': import('@lumino/signaling') as any,
-  '@lumino/virtualdom': import('@lumino/virtualdom') as any,
-  '@lumino/widgets': import('@lumino/widgets') as any,
-  'react': import('react') as any,
-  'react-dom': import('react-dom') as any
+import type { IModule } from './types';
+
+
+export function loadKnownModule(name: string): Promise<IModule | null> {
+  switch (name) {
+    case '@jupyter-widgets/base':
+      return import('@jupyter-widgets/base') as any;
+    case '@jupyterlab/application':
+      return import('@jupyterlab/application') as any;
+    case '@jupyterlab/apputils':
+      return import('@jupyterlab/apputils') as any;
+    case '@jupyterlab/cell-toolbar':
+      return import('@jupyterlab/cell-toolbar') as any;
+    case '@jupyterlab/codeeditor':
+      return import('@jupyterlab/codeeditor') as any;
+    case '@jupyterlab/codemirror':
+      return import('@jupyterlab/codemirror') as any;
+    case '@jupyterlab/completer':
+      return import('@jupyterlab/completer') as any;
+    case '@jupyterlab/console':
+      return import('@jupyterlab/console') as any;
+    case '@jupyterlab/coreutils':
+      return import('@jupyterlab/coreutils') as any;
+    case '@jupyterlab/debugger':
+      return import('@jupyterlab/debugger') as any;
+    case '@jupyterlab/docmanager':
+      return import('@jupyterlab/docmanager') as any;
+    case '@jupyterlab/docprovider':
+      return import('@jupyterlab/docprovider') as any;
+    case '@jupyterlab/docregistry':
+      return import('@jupyterlab/docregistry') as any;
+    case '@jupyterlab/documentsearch':
+      return import('@jupyterlab/documentsearch') as any;
+    case '@jupyterlab/extensionmanager':
+      return import('@jupyterlab/extensionmanager') as any;
+    case '@jupyterlab/filebrowser':
+      return import('@jupyterlab/filebrowser') as any;
+    case '@jupyterlab/fileeditor':
+      return import('@jupyterlab/fileeditor') as any;
+    case '@jupyterlab/imageviewer':
+      return import('@jupyterlab/imageviewer') as any;
+    case '@jupyterlab/inspector':
+      return import('@jupyterlab/inspector') as any;
+    case '@jupyterlab/launcher':
+      return import('@jupyterlab/launcher') as any;
+    case '@jupyterlab/logconsole':
+      return import('@jupyterlab/logconsole') as any;
+    case '@jupyterlab/mainmenu':
+      return import('@jupyterlab/mainmenu') as any;
+    case '@jupyterlab/markdownviewer':
+      return import('@jupyterlab/markdownviewer') as any;
+    case '@jupyterlab/notebook':
+      return import('@jupyterlab/notebook') as any;
+    case '@jupyterlab/outputarea':
+      return import('@jupyterlab/outputarea') as any;
+    case '@jupyterlab/rendermime':
+      return import('@jupyterlab/rendermime') as any;
+    case '@jupyterlab/rendermime-interfaces':
+      return import('@jupyterlab/rendermime-interfaces') as any;
+    case '@jupyterlab/services':
+      return import('@jupyterlab/services') as any;
+    case '@jupyterlab/settingeditor':
+      return import('@jupyterlab/settingeditor') as any;
+    case '@jupyterlab/settingregistry':
+      return import('@jupyterlab/settingregistry') as any;
+    case '@jupyterlab/shared-models':
+      return import('@jupyterlab/shared-models') as any;
+    case '@jupyterlab/statedb':
+      return import('@jupyterlab/statedb') as any;
+    case '@jupyterlab/statusbar':
+      return import('@jupyterlab/statusbar') as any;
+    case '@jupyterlab/terminal':
+      return import('@jupyterlab/terminal') as any;
+    case '@jupyterlab/toc':
+      return import('@jupyterlab/toc') as any;
+    case '@jupyterlab/tooltip':
+      return import('@jupyterlab/tooltip') as any;
+    case '@jupyterlab/translation':
+      return import('@jupyterlab/translation') as any;
+    case '@jupyterlab/ui-components':
+      return import('@jupyterlab/ui-components') as any;
+    case '@lumino/algorithm':
+      return import('@lumino/algorithm') as any;
+    case '@lumino/application':
+      return import('@lumino/application') as any;
+    case '@lumino/commands':
+      return import('@lumino/commands') as any;
+    case '@lumino/coreutils':
+      return import('@lumino/coreutils') as any;
+    case '@lumino/datagrid':
+      return import('@lumino/datagrid') as any;
+    case '@lumino/disposable':
+      return import('@lumino/disposable') as any;
+    case '@lumino/domutils':
+      return import('@lumino/domutils') as any;
+    case '@lumino/dragdrop':
+      return import('@lumino/dragdrop') as any;
+    case '@lumino/messaging':
+      return import('@lumino/messaging') as any;
+    case '@lumino/properties':
+      return import('@lumino/properties') as any;
+    case '@lumino/signaling':
+      return import('@lumino/signaling') as any;
+    case '@lumino/virtualdom':
+      return import('@lumino/virtualdom') as any;
+    case '@lumino/widgets':
+      return import('@lumino/widgets') as any;
+    case 'react':
+      return import('react') as any;
+    case 'react-dom':
+      return import('react-dom') as any;
+    default:
+      return Promise.resolve(null);
+  }
 };

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -1,107 +1,56 @@
-import * as jupyter_widgets_base from '@jupyter-widgets/base';
-import * as jupyterlab_application from '@jupyterlab/application';
-import * as jupyterlab_apputils from '@jupyterlab/apputils';
-import * as jupyterlab_codeeditor from '@jupyterlab/codeeditor';
-import * as jupyterlab_codemirror from '@jupyterlab/codemirror';
-import * as jupyterlab_completer from '@jupyterlab/completer';
-import * as jupyterlab_console from '@jupyterlab/console';
-import * as jupyterlab_coreutils from '@jupyterlab/coreutils';
-import * as jupyterlab_debugger from '@jupyterlab/debugger';
-import * as jupyterlab_docmanager from '@jupyterlab/docmanager';
-import * as jupyterlab_docprovider from '@jupyterlab/docprovider';
-import * as jupyterlab_docregistry from '@jupyterlab/docregistry';
-import * as jupyterlab_documentsearch from '@jupyterlab/documentsearch';
-import * as jupyterlab_extensionmanager from '@jupyterlab/extensionmanager';
-import * as jupyterlab_filebrowser from '@jupyterlab/filebrowser';
-import * as jupyterlab_fileeditor from '@jupyterlab/fileeditor';
-import * as jupyterlab_imageviewer from '@jupyterlab/imageviewer';
-import * as jupyterlab_inspector from '@jupyterlab/inspector';
-import * as jupyterlab_launcher from '@jupyterlab/launcher';
-import * as jupyterlab_logconsole from '@jupyterlab/logconsole';
-import * as jupyterlab_mainmenu from '@jupyterlab/mainmenu';
-import * as jupyterlab_markdownviewer from '@jupyterlab/markdownviewer';
-import * as jupyterlab_notebook from '@jupyterlab/notebook';
-import * as jupyterlab_outputarea from '@jupyterlab/outputarea';
-import * as jupyterlab_rendermime from '@jupyterlab/rendermime';
-import * as jupyterlab_rendermime_interfaces from '@jupyterlab/rendermime-interfaces';
-import * as jupyterlab_services from '@jupyterlab/services';
-import * as jupyterlab_settingeditor from '@jupyterlab/settingeditor';
-import * as jupyterlab_settingregistry from '@jupyterlab/settingregistry';
-import * as jupyterlab_shared_models from '@jupyterlab/shared-models';
-import * as jupyterlab_statedb from '@jupyterlab/statedb';
-import * as jupyterlab_statusbar from '@jupyterlab/statusbar';
-import * as jupyterlab_terminal from '@jupyterlab/terminal';
-import * as jupyterlab_toc from '@jupyterlab/toc';
-import * as jupyterlab_tooltip from '@jupyterlab/tooltip';
-import * as jupyterlab_translation from '@jupyterlab/translation';
-import * as jupyterlab_ui_components from '@jupyterlab/ui-components';
-import * as lumino_algorithm from '@lumino/algorithm';
-import * as lumino_application from '@lumino/application';
-import * as lumino_commands from '@lumino/commands';
-import * as lumino_coreutils from '@lumino/coreutils';
-import * as lumino_datagrid from '@lumino/datagrid';
-import * as lumino_disposable from '@lumino/disposable';
-import * as lumino_domutils from '@lumino/domutils';
-import * as lumino_dragdrop from '@lumino/dragdrop';
-import * as lumino_messaging from '@lumino/messaging';
-import * as lumino_properties from '@lumino/properties';
-import * as lumino_signaling from '@lumino/signaling';
-import * as lumino_virtualdom from '@lumino/virtualdom';
-import * as lumino_widgets from '@lumino/widgets';
-import * as react from 'react';
-import * as react_dom from 'react-dom';
-
 export const modules = {
-  '@jupyter-widgets/base': jupyter_widgets_base,
-  '@jupyterlab/application': jupyterlab_application,
-  '@jupyterlab/apputils': jupyterlab_apputils,
-  '@jupyterlab/codeeditor': jupyterlab_codeeditor,
-  '@jupyterlab/codemirror': jupyterlab_codemirror,
-  '@jupyterlab/completer': jupyterlab_completer,
-  '@jupyterlab/console': jupyterlab_console,
-  '@jupyterlab/coreutils': jupyterlab_coreutils,
-  '@jupyterlab/debugger': jupyterlab_debugger,
-  '@jupyterlab/docmanager': jupyterlab_docmanager,
-  '@jupyterlab/docprovider': jupyterlab_docprovider,
-  '@jupyterlab/docregistry': jupyterlab_docregistry,
-  '@jupyterlab/documentsearch': jupyterlab_documentsearch,
-  '@jupyterlab/extensionmanager': jupyterlab_extensionmanager,
-  '@jupyterlab/filebrowser': jupyterlab_filebrowser,
-  '@jupyterlab/fileeditor': jupyterlab_fileeditor,
-  '@jupyterlab/imageviewer': jupyterlab_imageviewer,
-  '@jupyterlab/inspector': jupyterlab_inspector,
-  '@jupyterlab/launcher': jupyterlab_launcher,
-  '@jupyterlab/logconsole': jupyterlab_logconsole,
-  '@jupyterlab/mainmenu': jupyterlab_mainmenu,
-  '@jupyterlab/markdownviewer': jupyterlab_markdownviewer,
-  '@jupyterlab/notebook': jupyterlab_notebook,
-  '@jupyterlab/outputarea': jupyterlab_outputarea,
-  '@jupyterlab/rendermime': jupyterlab_rendermime,
-  '@jupyterlab/rendermime-interfaces': jupyterlab_rendermime_interfaces,
-  '@jupyterlab/services': jupyterlab_services,
-  '@jupyterlab/settingeditor': jupyterlab_settingeditor,
-  '@jupyterlab/settingregistry': jupyterlab_settingregistry,
-  '@jupyterlab/shared-models': jupyterlab_shared_models,
-  '@jupyterlab/statedb': jupyterlab_statedb,
-  '@jupyterlab/statusbar': jupyterlab_statusbar,
-  '@jupyterlab/terminal': jupyterlab_terminal,
-  '@jupyterlab/toc': jupyterlab_toc,
-  '@jupyterlab/tooltip': jupyterlab_tooltip,
-  '@jupyterlab/translation': jupyterlab_translation,
-  '@jupyterlab/ui-components': jupyterlab_ui_components,
-  '@lumino/algorithm': lumino_algorithm,
-  '@lumino/application': lumino_application,
-  '@lumino/commands': lumino_commands,
-  '@lumino/coreutils': lumino_coreutils,
-  '@lumino/datagrid': lumino_datagrid,
-  '@lumino/disposable': lumino_disposable,
-  '@lumino/domutils': lumino_domutils,
-  '@lumino/dragdrop': lumino_dragdrop,
-  '@lumino/messaging': lumino_messaging,
-  '@lumino/properties': lumino_properties,
-  '@lumino/signaling': lumino_signaling,
-  '@lumino/virtualdom': lumino_virtualdom,
-  '@lumino/widgets': lumino_widgets,
-  react: react,
-  'react-dom': react_dom
+  '@jupyter-widgets/base': import('@jupyter-widgets/base') as any,
+  '@jupyterlab/application': import('@jupyterlab/application') as any,
+  '@jupyterlab/apputils': import('@jupyterlab/apputils') as any,
+  '@jupyterlab/cell-toolbar': import('@jupyterlab/cell-toolbar') as any,
+  '@jupyterlab/codeeditor': import('@jupyterlab/codeeditor') as any,
+  '@jupyterlab/codemirror': import('@jupyterlab/codemirror') as any,
+  '@jupyterlab/collaboration': import('@jupyterlab/collaboration') as any,
+  '@jupyterlab/completer': import('@jupyterlab/completer') as any,
+  '@jupyterlab/console': import('@jupyterlab/console') as any,
+  '@jupyterlab/coreutils': import('@jupyterlab/coreutils') as any,
+  '@jupyterlab/debugger': import('@jupyterlab/debugger') as any,
+  '@jupyterlab/docmanager': import('@jupyterlab/docmanager') as any,
+  '@jupyterlab/docprovider': import('@jupyterlab/docprovider') as any,
+  '@jupyterlab/docregistry': import('@jupyterlab/docregistry') as any,
+  '@jupyterlab/documentsearch': import('@jupyterlab/documentsearch') as any,
+  '@jupyterlab/extensionmanager': import('@jupyterlab/extensionmanager') as any,
+  '@jupyterlab/filebrowser': import('@jupyterlab/filebrowser') as any,
+  '@jupyterlab/fileeditor': import('@jupyterlab/fileeditor') as any,
+  '@jupyterlab/imageviewer': import('@jupyterlab/imageviewer') as any,
+  '@jupyterlab/inspector': import('@jupyterlab/inspector') as any,
+  '@jupyterlab/launcher': import('@jupyterlab/launcher') as any,
+  '@jupyterlab/logconsole': import('@jupyterlab/logconsole') as any,
+  '@jupyterlab/mainmenu': import('@jupyterlab/mainmenu') as any,
+  '@jupyterlab/markdownviewer': import('@jupyterlab/markdownviewer') as any,
+  '@jupyterlab/notebook': import('@jupyterlab/notebook') as any,
+  '@jupyterlab/outputarea': import('@jupyterlab/outputarea') as any,
+  '@jupyterlab/rendermime': import('@jupyterlab/rendermime') as any,
+  '@jupyterlab/rendermime-interfaces': import('@jupyterlab/rendermime-interfaces') as any,
+  '@jupyterlab/services': import('@jupyterlab/services') as any,
+  '@jupyterlab/settingeditor': import('@jupyterlab/settingeditor') as any,
+  '@jupyterlab/settingregistry': import('@jupyterlab/settingregistry') as any,
+  '@jupyterlab/shared-models': import('@jupyterlab/shared-models') as any,
+  '@jupyterlab/statedb': import('@jupyterlab/statedb') as any,
+  '@jupyterlab/statusbar': import('@jupyterlab/statusbar') as any,
+  '@jupyterlab/terminal': import('@jupyterlab/terminal') as any,
+  '@jupyterlab/toc': import('@jupyterlab/toc') as any,
+  '@jupyterlab/tooltip': import('@jupyterlab/tooltip') as any,
+  '@jupyterlab/translation': import('@jupyterlab/translation') as any,
+  '@jupyterlab/ui-components': import('@jupyterlab/ui-components') as any,
+  '@lumino/algorithm': import('@lumino/algorithm') as any,
+  '@lumino/application': import('@lumino/application') as any,
+  '@lumino/commands': import('@lumino/commands') as any,
+  '@lumino/coreutils': import('@lumino/coreutils') as any,
+  '@lumino/datagrid': import('@lumino/datagrid') as any,
+  '@lumino/disposable': import('@lumino/disposable') as any,
+  '@lumino/domutils': import('@lumino/domutils') as any,
+  '@lumino/dragdrop': import('@lumino/dragdrop') as any,
+  '@lumino/messaging': import('@lumino/messaging') as any,
+  '@lumino/properties': import('@lumino/properties') as any,
+  '@lumino/signaling': import('@lumino/signaling') as any,
+  '@lumino/virtualdom': import('@lumino/virtualdom') as any,
+  '@lumino/widgets': import('@lumino/widgets') as any,
+  'react': import('react') as any,
+  'react-dom': import('react-dom') as any
 };

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -25,7 +25,7 @@ function handleImportError(error: Error, module: string) {
 
 export namespace ImportResolver {
   export interface IOptions {
-    modules: Record<string, Promise<IModule>>;
+    loadKnownModule: (name: string) => Promise<IModule | null>;
     tokenMap: Map<string, Token<any>>;
     requirejs: IRequireJS;
     settings: ISettingRegistry.ISettings;
@@ -172,10 +172,7 @@ export class ImportResolver {
   }
 
   private async _resolveKnownModule(module: string): Promise<IModule | null> {
-    if (Object.prototype.hasOwnProperty.call(this._options.modules, module)) {
-      return this._options.modules[module];
-    }
-    return null;
+    return this._options.loadKnownModule(module);
   }
 
   private async _resolveAMDModule(

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -25,7 +25,7 @@ function handleImportError(error: Error, module: string) {
 
 export namespace ImportResolver {
   export interface IOptions {
-    modules: Record<string, IModule>;
+    modules: Record<string, Promise<IModule>>;
     tokenMap: Map<string, Token<any>>;
     requirejs: IRequireJS;
     settings: ISettingRegistry.ISettings;
@@ -115,7 +115,7 @@ export class ImportResolver {
         }
       };
 
-      const knownModule = this._resolveKnownModule(module);
+      const knownModule = await this._resolveKnownModule(module);
       if (knownModule !== null) {
         return new Proxy(knownModule, tokenAndDefaultHandler);
       }
@@ -171,7 +171,7 @@ export class ImportResolver {
     }
   }
 
-  private _resolveKnownModule(module: string): IModule | null {
+  private async _resolveKnownModule(module: string): Promise<IModule | null> {
     if (Object.prototype.hasOwnProperty.call(this._options.modules, module)) {
       return this._options.modules[module];
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -232,6 +232,35 @@
     sanitize-html "~2.5.3"
     url "^0.11.0"
 
+"@jupyterlab/apputils@^3.5.0", "@jupyterlab/apputils@^3.5.0-beta.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/apputils/-/apputils-3.5.0.tgz#9ce715f6d56d3647798dc8d1108c638466459d3f"
+  integrity sha512-brL1CR0F2ocxt+YSWQGRh9OoJWxlqQb5BxQNJy+qJceCpwkMyZmZyf2gxHc9bu67HkL96Sa46wGIn6WKobARrA==
+  dependencies:
+    "@jupyterlab/coreutils" "^5.5.0"
+    "@jupyterlab/observables" "^4.5.0"
+    "@jupyterlab/services" "^6.5.0"
+    "@jupyterlab/settingregistry" "^3.5.0"
+    "@jupyterlab/statedb" "^3.5.0"
+    "@jupyterlab/translation" "^3.5.0"
+    "@jupyterlab/ui-components" "^3.5.0"
+    "@lumino/algorithm" "^1.9.0"
+    "@lumino/commands" "^1.19.0"
+    "@lumino/coreutils" "^1.11.0"
+    "@lumino/disposable" "^1.10.0"
+    "@lumino/domutils" "^1.8.0"
+    "@lumino/messaging" "^1.10.0"
+    "@lumino/polling" "^1.9.0"
+    "@lumino/properties" "^1.8.0"
+    "@lumino/signaling" "^1.10.0"
+    "@lumino/virtualdom" "^1.14.0"
+    "@lumino/widgets" "^1.33.0"
+    "@types/react" "^17.0.0"
+    react "^17.0.1"
+    react-dom "^17.0.1"
+    sanitize-html "~2.5.3"
+    url "^0.11.0"
+
 "@jupyterlab/attachments@^3.2.5":
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/@jupyterlab/attachments/-/attachments-3.2.5.tgz#57479f4c76d5a65b52ddda98d07f9b1cd6eccb18"
@@ -243,6 +272,18 @@
     "@jupyterlab/rendermime-interfaces" "^3.2.5"
     "@lumino/disposable" "^1.4.3"
     "@lumino/signaling" "^1.4.3"
+
+"@jupyterlab/attachments@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/attachments/-/attachments-3.5.0.tgz#739fa29a5c95f6135e8ad45f3992247882764456"
+  integrity sha512-IaSlzQ7VD680/mcKAVkOgUjRtqpUXCd91XRa5gjD+lBKvS+E0dNBY/cpmpgUEPw9Z07bwRW3+Zq8ATitcmy/gw==
+  dependencies:
+    "@jupyterlab/nbformat" "^3.5.0"
+    "@jupyterlab/observables" "^4.5.0"
+    "@jupyterlab/rendermime" "^3.5.0"
+    "@jupyterlab/rendermime-interfaces" "^3.5.0"
+    "@lumino/disposable" "^1.10.0"
+    "@lumino/signaling" "^1.10.0"
 
 "@jupyterlab/builder@^3.0.0":
   version "3.2.5"
@@ -309,6 +350,22 @@
     typescript "~4.1.3"
     verdaccio "^5.1.1"
 
+"@jupyterlab/cell-toolbar@^3.4.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/cell-toolbar/-/cell-toolbar-3.5.0.tgz#7cee1ef83113c2b7804fd5fb7f3cba0475ae0f1a"
+  integrity sha512-IOlo912L1EX9okgfeS7WsgFsVQTRoYIZJ5wWUfKuCMhureNsKdGiyRGwfYBZSvK6KDlTTqDqCDlozZoRDaxULg==
+  dependencies:
+    "@jupyterlab/apputils" "^3.5.0"
+    "@jupyterlab/cells" "^3.5.0"
+    "@jupyterlab/docregistry" "^3.5.0"
+    "@jupyterlab/notebook" "^3.5.0"
+    "@jupyterlab/observables" "^4.5.0"
+    "@lumino/algorithm" "^1.9.0"
+    "@lumino/commands" "^1.19.0"
+    "@lumino/disposable" "^1.10.0"
+    "@lumino/signaling" "^1.10.0"
+    "@lumino/widgets" "^1.33.0"
+
 "@jupyterlab/cells@^3.2.5":
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/@jupyterlab/cells/-/cells-3.2.5.tgz#cf58a1e595140ada1dd8c797ca09ab1600c9440e"
@@ -338,6 +395,36 @@
     marked "^2.0.0"
     react "^17.0.1"
 
+"@jupyterlab/cells@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/cells/-/cells-3.5.0.tgz#dd4598f66200e075abcecab7f0c92ecc46fb6123"
+  integrity sha512-2ogdSP5+OmLo1IgjE7/2Jyvgr+dAzI2aZNTntRsjAmeIsk5fZSyKk+5LJWPhAUYTghbIGL7vqSfYbaGG+kL5Ng==
+  dependencies:
+    "@jupyterlab/apputils" "^3.5.0"
+    "@jupyterlab/attachments" "^3.5.0"
+    "@jupyterlab/codeeditor" "^3.5.0"
+    "@jupyterlab/codemirror" "^3.5.0"
+    "@jupyterlab/coreutils" "^5.5.0"
+    "@jupyterlab/filebrowser" "^3.5.0"
+    "@jupyterlab/nbformat" "^3.5.0"
+    "@jupyterlab/observables" "^4.5.0"
+    "@jupyterlab/outputarea" "^3.5.0"
+    "@jupyterlab/rendermime" "^3.5.0"
+    "@jupyterlab/services" "^6.5.0"
+    "@jupyterlab/shared-models" "^3.5.0"
+    "@jupyterlab/ui-components" "^3.5.0"
+    "@lumino/algorithm" "^1.9.0"
+    "@lumino/coreutils" "^1.11.0"
+    "@lumino/domutils" "^1.8.0"
+    "@lumino/dragdrop" "^1.13.0"
+    "@lumino/messaging" "^1.10.0"
+    "@lumino/polling" "^1.9.0"
+    "@lumino/signaling" "^1.10.0"
+    "@lumino/virtualdom" "^1.14.0"
+    "@lumino/widgets" "^1.33.0"
+    marked "^4.0.17"
+    react "^17.0.1"
+
 "@jupyterlab/codeeditor@^3.2.5":
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/@jupyterlab/codeeditor/-/codeeditor-3.2.5.tgz#5514cef01bc0f7a6e06d76f014a6db87b9b5df5f"
@@ -355,6 +442,24 @@
     "@lumino/messaging" "^1.4.3"
     "@lumino/signaling" "^1.4.3"
     "@lumino/widgets" "^1.19.0"
+
+"@jupyterlab/codeeditor@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/codeeditor/-/codeeditor-3.5.0.tgz#b5345f028196c68077424b4a9f33ca315ec49828"
+  integrity sha512-imdYuovxyIIQqZdoRnZAr0VQHqiIVPPFwk8hAgDYtfl8VxFOPMTh203Z6y+CLv5V62J03OU7HZutP/f5u1nZ1w==
+  dependencies:
+    "@jupyterlab/coreutils" "^5.5.0"
+    "@jupyterlab/nbformat" "^3.5.0"
+    "@jupyterlab/observables" "^4.5.0"
+    "@jupyterlab/shared-models" "^3.5.0"
+    "@jupyterlab/translation" "^3.5.0"
+    "@jupyterlab/ui-components" "^3.5.0"
+    "@lumino/coreutils" "^1.11.0"
+    "@lumino/disposable" "^1.10.0"
+    "@lumino/dragdrop" "^1.13.0"
+    "@lumino/messaging" "^1.10.0"
+    "@lumino/signaling" "^1.10.0"
+    "@lumino/widgets" "^1.33.0"
 
 "@jupyterlab/codemirror@^3.2.5":
   version "3.2.5"
@@ -379,6 +484,47 @@
     codemirror "~5.61.0"
     react "^17.0.1"
     y-codemirror "^3.0.1"
+
+"@jupyterlab/codemirror@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/codemirror/-/codemirror-3.5.0.tgz#b16190e99584acfb0b18c44dd1c005366a829062"
+  integrity sha512-i6rGYLnWsBuL8zkCpPTCMeZc2lHI5pIgtEpO/CEfeigYhZI9NkaLSiF64Jwt8bgurS10O02bxl+3hIgU3mSSQA==
+  dependencies:
+    "@jupyterlab/apputils" "^3.5.0"
+    "@jupyterlab/codeeditor" "^3.5.0"
+    "@jupyterlab/coreutils" "^5.5.0"
+    "@jupyterlab/nbformat" "^3.5.0"
+    "@jupyterlab/observables" "^4.5.0"
+    "@jupyterlab/shared-models" "^3.5.0"
+    "@jupyterlab/statusbar" "^3.5.0"
+    "@jupyterlab/translation" "^3.5.0"
+    "@lumino/algorithm" "^1.9.0"
+    "@lumino/commands" "^1.19.0"
+    "@lumino/coreutils" "^1.11.0"
+    "@lumino/disposable" "^1.10.0"
+    "@lumino/polling" "^1.9.0"
+    "@lumino/signaling" "^1.10.0"
+    "@lumino/widgets" "^1.33.0"
+    codemirror "~5.61.0"
+    react "^17.0.1"
+    y-codemirror "^3.0.1"
+
+"@jupyterlab/collaboration@^3.5.0-beta.0":
+  version "3.5.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/collaboration/-/collaboration-3.5.0-beta.0.tgz#bb30924eebb97427d6578d207e79915cb66a93c0"
+  integrity sha512-Kb1fKuYHXkjiiLkZZOTPTrZKRby4BHR9kM8AdOrF+4OspgXz7G4zqaSUjH+4I/x0Ca3a9WHS12AJJL6dbHyx8g==
+  dependencies:
+    "@jupyterlab/apputils" "^3.5.0-beta.0"
+    "@jupyterlab/coreutils" "^5.5.0-beta.0"
+    "@jupyterlab/services" "^6.5.0-beta.0"
+    "@jupyterlab/ui-components" "^3.5.0-beta.0"
+    "@lumino/coreutils" "^1.11.0"
+    "@lumino/signaling" "^1.10.0"
+    "@lumino/virtualdom" "^1.14.0"
+    "@lumino/widgets" "^1.33.0"
+    react "^17.0.1"
+    y-protocols "^1.0.5"
+    yjs "^13.5.17"
 
 "@jupyterlab/completer@^3.2.5":
   version "3.2.5"
@@ -430,6 +576,19 @@
     "@lumino/coreutils" "^1.5.3"
     "@lumino/disposable" "^1.4.3"
     "@lumino/signaling" "^1.4.3"
+    minimist "~1.2.0"
+    moment "^2.24.0"
+    path-browserify "^1.0.0"
+    url-parse "~1.5.1"
+
+"@jupyterlab/coreutils@^5.5.0", "@jupyterlab/coreutils@^5.5.0-beta.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/coreutils/-/coreutils-5.5.0.tgz#0cbceb74e75a96cc69c8dd14b61f37d8ea940d75"
+  integrity sha512-mVBuVDUA87hvtS5DfbjfLIE1EFdhAGEU8f19G33QfhD/w2vYDi7vE4ro4arNT47r17MzXW4XfaE4LwatR6uvPw==
+  dependencies:
+    "@lumino/coreutils" "^1.11.0"
+    "@lumino/disposable" "^1.10.0"
+    "@lumino/signaling" "^1.10.0"
     minimist "~1.2.0"
     moment "^2.24.0"
     path-browserify "^1.0.0"
@@ -488,6 +647,27 @@
     "@lumino/widgets" "^1.19.0"
     react "^17.0.1"
 
+"@jupyterlab/docmanager@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/docmanager/-/docmanager-3.5.0.tgz#80dd3ffe688436b5d98f73b7de1de588f7929fce"
+  integrity sha512-IkPUXpI6zcGufGwetge6F/b5pyF9CLYb/xdK+fuN61jub8aEWFE4vebXNhb1rhmyjynjDwSmLcUTX3slFTItRA==
+  dependencies:
+    "@jupyterlab/apputils" "^3.5.0"
+    "@jupyterlab/coreutils" "^5.5.0"
+    "@jupyterlab/docprovider" "^3.5.0"
+    "@jupyterlab/docregistry" "^3.5.0"
+    "@jupyterlab/services" "^6.5.0"
+    "@jupyterlab/statusbar" "^3.5.0"
+    "@jupyterlab/translation" "^3.5.0"
+    "@lumino/algorithm" "^1.9.0"
+    "@lumino/coreutils" "^1.11.0"
+    "@lumino/disposable" "^1.10.0"
+    "@lumino/messaging" "^1.10.0"
+    "@lumino/properties" "^1.8.0"
+    "@lumino/signaling" "^1.10.0"
+    "@lumino/widgets" "^1.33.0"
+    react "^17.0.1"
+
 "@jupyterlab/docprovider@^3.2.5":
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/@jupyterlab/docprovider/-/docprovider-3.2.5.tgz#3d1cd9d9535adc14b71af1875c27daeee78f74bd"
@@ -495,6 +675,17 @@
   dependencies:
     "@jupyterlab/shared-models" "^3.2.5"
     "@lumino/coreutils" "^1.5.3"
+    lib0 "^0.2.42"
+    y-websocket "^1.3.15"
+    yjs "^13.5.17"
+
+"@jupyterlab/docprovider@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/docprovider/-/docprovider-3.5.0.tgz#8593ada08c0e7ec014084e16e918d26aac14c441"
+  integrity sha512-F5VtIIDUpWEFKc0S/xDs8GIjEZC/xn6SVrdNY0+ixDPyC5VNJo+IU5JmqrcU25DlJ+jMbnKlPdRLYsRtJTDKrw==
+  dependencies:
+    "@jupyterlab/shared-models" "^3.5.0"
+    "@lumino/coreutils" "^1.11.0"
     lib0 "^0.2.42"
     y-websocket "^1.3.15"
     yjs "^13.5.17"
@@ -522,6 +713,31 @@
     "@lumino/messaging" "^1.4.3"
     "@lumino/signaling" "^1.4.3"
     "@lumino/widgets" "^1.19.0"
+    yjs "^13.5.17"
+
+"@jupyterlab/docregistry@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/docregistry/-/docregistry-3.5.0.tgz#aa3ebc2cd676f7ff564dd055fdd629f0dd16b5b1"
+  integrity sha512-OdP+q4rvZARqJvZWCyae23K8IHN+TvSP0xPyTVHd1aXFXi6cWlNUOUGRHd9TlEUNqyJxKjkZNuhozMu8ANEBAQ==
+  dependencies:
+    "@jupyterlab/apputils" "^3.5.0"
+    "@jupyterlab/codeeditor" "^3.5.0"
+    "@jupyterlab/codemirror" "^3.5.0"
+    "@jupyterlab/coreutils" "^5.5.0"
+    "@jupyterlab/docprovider" "^3.5.0"
+    "@jupyterlab/observables" "^4.5.0"
+    "@jupyterlab/rendermime" "^3.5.0"
+    "@jupyterlab/rendermime-interfaces" "^3.5.0"
+    "@jupyterlab/services" "^6.5.0"
+    "@jupyterlab/shared-models" "^3.5.0"
+    "@jupyterlab/translation" "^3.5.0"
+    "@jupyterlab/ui-components" "^3.5.0"
+    "@lumino/algorithm" "^1.9.0"
+    "@lumino/coreutils" "^1.11.0"
+    "@lumino/disposable" "^1.10.0"
+    "@lumino/messaging" "^1.10.0"
+    "@lumino/signaling" "^1.10.0"
+    "@lumino/widgets" "^1.33.0"
     yjs "^13.5.17"
 
 "@jupyterlab/documentsearch@^3.2.5":
@@ -589,6 +805,32 @@
     "@lumino/signaling" "^1.4.3"
     "@lumino/virtualdom" "^1.8.0"
     "@lumino/widgets" "^1.19.0"
+    react "^17.0.1"
+
+"@jupyterlab/filebrowser@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/filebrowser/-/filebrowser-3.5.0.tgz#3dda05e314f9e20bac9e734ac103db81760c85b7"
+  integrity sha512-7e/AAbkgzG7pR5cO3HCWQwO87tde4/vqnG8u+H0b5DuUy1EIAU+xHyAfCV6x2XXyLsXl1lhMNSPgT+PVvoKynQ==
+  dependencies:
+    "@jupyterlab/apputils" "^3.5.0"
+    "@jupyterlab/coreutils" "^5.5.0"
+    "@jupyterlab/docmanager" "^3.5.0"
+    "@jupyterlab/docregistry" "^3.5.0"
+    "@jupyterlab/services" "^6.5.0"
+    "@jupyterlab/statedb" "^3.5.0"
+    "@jupyterlab/statusbar" "^3.5.0"
+    "@jupyterlab/translation" "^3.5.0"
+    "@jupyterlab/ui-components" "^3.5.0"
+    "@lumino/algorithm" "^1.9.0"
+    "@lumino/coreutils" "^1.11.0"
+    "@lumino/disposable" "^1.10.0"
+    "@lumino/domutils" "^1.8.0"
+    "@lumino/dragdrop" "^1.13.0"
+    "@lumino/messaging" "^1.10.0"
+    "@lumino/polling" "^1.9.0"
+    "@lumino/signaling" "^1.10.0"
+    "@lumino/virtualdom" "^1.14.0"
+    "@lumino/widgets" "^1.33.0"
     react "^17.0.1"
 
 "@jupyterlab/fileeditor@^3.0.0", "@jupyterlab/fileeditor@^3.2.5":
@@ -705,6 +947,13 @@
   dependencies:
     "@lumino/coreutils" "^1.5.3"
 
+"@jupyterlab/nbformat@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/nbformat/-/nbformat-3.5.0.tgz#ea3d926b90db9ff2da988db1ea3c8ac1dc3ba9fa"
+  integrity sha512-tQ0MCJ2NSlGTYM7auiL2vdqirIv39Pd2/gfFd4XdHClJgvT65b7XkNDOwBv6mqIuhNdHo3Mc3RXiODTo1tle7Q==
+  dependencies:
+    "@lumino/coreutils" "^1.11.0"
+
 "@jupyterlab/notebook@^3.2.5":
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/@jupyterlab/notebook/-/notebook-3.2.5.tgz#86b21fe481c6699edfb1db4710cbb0d846980d5b"
@@ -734,6 +983,36 @@
     "@lumino/widgets" "^1.19.0"
     react "^17.0.1"
 
+"@jupyterlab/notebook@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/notebook/-/notebook-3.5.0.tgz#50e997e89037949c14c7038d08ae2939a2baa5c8"
+  integrity sha512-NGocuZiIcZ6mWXMLdenj2/qtLiJFCUlWzIp5bbwW6yu4whNxVMG8CEAomyUKWIbJFe0XuT9ZRLocUV82mOGH+A==
+  dependencies:
+    "@jupyterlab/apputils" "^3.5.0"
+    "@jupyterlab/cells" "^3.5.0"
+    "@jupyterlab/codeeditor" "^3.5.0"
+    "@jupyterlab/coreutils" "^5.5.0"
+    "@jupyterlab/docregistry" "^3.5.0"
+    "@jupyterlab/nbformat" "^3.5.0"
+    "@jupyterlab/observables" "^4.5.0"
+    "@jupyterlab/rendermime" "^3.5.0"
+    "@jupyterlab/services" "^6.5.0"
+    "@jupyterlab/settingregistry" "^3.5.0"
+    "@jupyterlab/shared-models" "^3.5.0"
+    "@jupyterlab/statusbar" "^3.5.0"
+    "@jupyterlab/translation" "^3.5.0"
+    "@jupyterlab/ui-components" "^3.5.0"
+    "@lumino/algorithm" "^1.9.0"
+    "@lumino/coreutils" "^1.11.0"
+    "@lumino/domutils" "^1.8.0"
+    "@lumino/dragdrop" "^1.13.0"
+    "@lumino/messaging" "^1.10.0"
+    "@lumino/properties" "^1.8.0"
+    "@lumino/signaling" "^1.10.0"
+    "@lumino/virtualdom" "^1.14.0"
+    "@lumino/widgets" "^1.33.0"
+    react "^17.0.1"
+
 "@jupyterlab/observables@^4.1.17", "@jupyterlab/observables@^4.2.5":
   version "4.2.5"
   resolved "https://registry.yarnpkg.com/@jupyterlab/observables/-/observables-4.2.5.tgz#f31b166c66dddc7d34f49b8bc3a6d2d137b327f5"
@@ -744,6 +1023,17 @@
     "@lumino/disposable" "^1.4.3"
     "@lumino/messaging" "^1.4.3"
     "@lumino/signaling" "^1.4.3"
+
+"@jupyterlab/observables@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/observables/-/observables-4.5.0.tgz#3cba31bf2358c11f3c7ba39b7aa840e727733405"
+  integrity sha512-YiUljeHNz80YpIPDi0zoUC26AwAhyDu1UXm2kH5J/lPViycz8X22RWXkIBc40kvWoasUTSomZiEv/W2hFUs0Vw==
+  dependencies:
+    "@lumino/algorithm" "^1.9.0"
+    "@lumino/coreutils" "^1.11.0"
+    "@lumino/disposable" "^1.10.0"
+    "@lumino/messaging" "^1.10.0"
+    "@lumino/signaling" "^1.10.0"
 
 "@jupyterlab/outputarea@^3.2.5":
   version "3.2.5"
@@ -765,6 +1055,26 @@
     "@lumino/widgets" "^1.19.0"
     resize-observer-polyfill "^1.5.1"
 
+"@jupyterlab/outputarea@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/outputarea/-/outputarea-3.5.0.tgz#9ecab47c4ce512a0c6d3ac3235ae924a8edcad09"
+  integrity sha512-GF9jXeQDUQw93w4+Oh7J8AjFzBjcXL9f0CmGCao0H4rjni1EFByU5eLPe0FM7YRubU9ike7JMu3+9dJDlnpdAA==
+  dependencies:
+    "@jupyterlab/apputils" "^3.5.0"
+    "@jupyterlab/nbformat" "^3.5.0"
+    "@jupyterlab/observables" "^4.5.0"
+    "@jupyterlab/rendermime" "^3.5.0"
+    "@jupyterlab/rendermime-interfaces" "^3.5.0"
+    "@jupyterlab/services" "^6.5.0"
+    "@lumino/algorithm" "^1.9.0"
+    "@lumino/coreutils" "^1.11.0"
+    "@lumino/disposable" "^1.10.0"
+    "@lumino/messaging" "^1.10.0"
+    "@lumino/properties" "^1.8.0"
+    "@lumino/signaling" "^1.10.0"
+    "@lumino/widgets" "^1.33.0"
+    resize-observer-polyfill "^1.5.1"
+
 "@jupyterlab/rendermime-interfaces@^3.2.5":
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-3.2.5.tgz#cd7144bb6c790e90a86cba682734fb5ac98a3452"
@@ -773,6 +1083,15 @@
     "@jupyterlab/translation" "^3.2.5"
     "@lumino/coreutils" "^1.5.3"
     "@lumino/widgets" "^1.19.0"
+
+"@jupyterlab/rendermime-interfaces@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-3.5.0.tgz#e833b1304ff1e86934fcb039dec7b5ffbf374ae9"
+  integrity sha512-SWpNX8dwRuAH0GMeuamN1O096Ypn2XcosNbo60P8860qi2KzTXgxADt5xcOf6FK+tXVQ+qi3hJi+055+1xjq+g==
+  dependencies:
+    "@jupyterlab/translation" "^3.5.0"
+    "@lumino/coreutils" "^1.11.0"
+    "@lumino/widgets" "^1.33.0"
 
 "@jupyterlab/rendermime@^3.2.5":
   version "3.2.5"
@@ -794,6 +1113,27 @@
     "@lumino/widgets" "^1.19.0"
     lodash.escape "^4.0.1"
     marked "^2.0.0"
+
+"@jupyterlab/rendermime@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/rendermime/-/rendermime-3.5.0.tgz#279a2672690b63ac23990b366f2dc5cdc786dacc"
+  integrity sha512-vA5bQA/v7/P/6a3WXdrSoTeGgIJy1iLvpVpJ3DfR9NIpPrXzazDtRplipwcHsNjtUn4P2oS8C46s/eTOEPsQOw==
+  dependencies:
+    "@jupyterlab/apputils" "^3.5.0"
+    "@jupyterlab/codemirror" "^3.5.0"
+    "@jupyterlab/coreutils" "^5.5.0"
+    "@jupyterlab/nbformat" "^3.5.0"
+    "@jupyterlab/observables" "^4.5.0"
+    "@jupyterlab/rendermime-interfaces" "^3.5.0"
+    "@jupyterlab/services" "^6.5.0"
+    "@jupyterlab/translation" "^3.5.0"
+    "@lumino/algorithm" "^1.9.0"
+    "@lumino/coreutils" "^1.11.0"
+    "@lumino/messaging" "^1.10.0"
+    "@lumino/signaling" "^1.10.0"
+    "@lumino/widgets" "^1.33.0"
+    lodash.escape "^4.0.1"
+    marked "^4.0.17"
 
 "@jupyterlab/services@^6.0.0":
   version "6.1.17"
@@ -831,6 +1171,24 @@
     node-fetch "^2.6.0"
     ws "^7.4.6"
 
+"@jupyterlab/services@^6.5.0", "@jupyterlab/services@^6.5.0-beta.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/services/-/services-6.5.0.tgz#cf89407d8f39ed708394e8ba14b5cba5b65b9cba"
+  integrity sha512-g5fa7oFu1I6i0agOmx6ud/1fjYAsr3zHzoymE4oAGN3nIbt8HTcmzLbiwmaWssGCVUF4h06GOYWcAe/x/ND8JA==
+  dependencies:
+    "@jupyterlab/coreutils" "^5.5.0"
+    "@jupyterlab/nbformat" "^3.5.0"
+    "@jupyterlab/observables" "^4.5.0"
+    "@jupyterlab/settingregistry" "^3.5.0"
+    "@jupyterlab/statedb" "^3.5.0"
+    "@lumino/algorithm" "^1.9.0"
+    "@lumino/coreutils" "^1.11.0"
+    "@lumino/disposable" "^1.10.0"
+    "@lumino/polling" "^1.9.0"
+    "@lumino/signaling" "^1.10.0"
+    node-fetch "^2.6.0"
+    ws "^7.4.6"
+
 "@jupyterlab/settingeditor@^3.2.5":
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/@jupyterlab/settingeditor/-/settingeditor-3.2.5.tgz#4f0cd7273eba744ca4b72150e49925ed0634c5b1"
@@ -865,6 +1223,19 @@
     ajv "^6.12.3"
     json5 "^2.1.1"
 
+"@jupyterlab/settingregistry@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/settingregistry/-/settingregistry-3.5.0.tgz#2a6a0c2771c61643ab4aff9355ac863b4c8fc0ab"
+  integrity sha512-y9H9U4iMVfe2btImp5DR9mGAs36Sow0hI6ajK61bhHVJ4CumYdFBd8drrQGuYcyk/Y4ypU5HO9EaLBQU3CLCug==
+  dependencies:
+    "@jupyterlab/statedb" "^3.5.0"
+    "@lumino/commands" "^1.19.0"
+    "@lumino/coreutils" "^1.11.0"
+    "@lumino/disposable" "^1.10.0"
+    "@lumino/signaling" "^1.10.0"
+    ajv "^6.12.3"
+    json5 "^2.1.1"
+
 "@jupyterlab/shared-models@^3.2.5":
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/@jupyterlab/shared-models/-/shared-models-3.2.5.tgz#3539b64084d4a6bf220e27be97c923e8c9d24101"
@@ -874,6 +1245,18 @@
     "@lumino/coreutils" "^1.5.3"
     "@lumino/disposable" "^1.4.3"
     "@lumino/signaling" "^1.4.3"
+    y-protocols "^1.0.5"
+    yjs "^13.5.17"
+
+"@jupyterlab/shared-models@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/shared-models/-/shared-models-3.5.0.tgz#d34b5ac6d0121ea8daf3862bb92926959aade209"
+  integrity sha512-QZL9BPCC+iV12AsUbUAwQvZeeo3fKh1X8h9odtlc+Oc+dyZAqREYXuZGjVlaG9qwbF62xDr7acfO4HqCK6Kjyw==
+  dependencies:
+    "@jupyterlab/nbformat" "^3.5.0"
+    "@lumino/coreutils" "^1.11.0"
+    "@lumino/disposable" "^1.10.0"
+    "@lumino/signaling" "^1.10.0"
     y-protocols "^1.0.5"
     yjs "^13.5.17"
 
@@ -887,6 +1270,17 @@
     "@lumino/disposable" "^1.4.3"
     "@lumino/properties" "^1.2.3"
     "@lumino/signaling" "^1.4.3"
+
+"@jupyterlab/statedb@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/statedb/-/statedb-3.5.0.tgz#6118a7cf339a3d5f033b7b61c3480bfd9bb97a48"
+  integrity sha512-S4/BjcfSN8tGMyL4jjrD4TMoLTABI3zkLjaqSNRfT6iyKnqN8VKcMHBZXOq90uWGkw+caQZ5GiL+L7uEtahE4w==
+  dependencies:
+    "@lumino/commands" "^1.19.0"
+    "@lumino/coreutils" "^1.11.0"
+    "@lumino/disposable" "^1.10.0"
+    "@lumino/properties" "^1.8.0"
+    "@lumino/signaling" "^1.10.0"
 
 "@jupyterlab/statusbar@^3.2.5":
   version "3.2.5"
@@ -904,6 +1298,26 @@
     "@lumino/messaging" "^1.4.3"
     "@lumino/signaling" "^1.4.3"
     "@lumino/widgets" "^1.19.0"
+    csstype "~3.0.3"
+    react "^17.0.1"
+    typestyle "^2.0.4"
+
+"@jupyterlab/statusbar@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/statusbar/-/statusbar-3.5.0.tgz#62155a3938f6aff6081820c54007d7cbae93bf68"
+  integrity sha512-kXgMN7x5V3bTWP45mahOt2SaNOMXgeohlMsIou9f+OHZeR++6dmMMKyHPnE7QXES4At26FQu3swRI+8+A2klgA==
+  dependencies:
+    "@jupyterlab/apputils" "^3.5.0"
+    "@jupyterlab/codeeditor" "^3.5.0"
+    "@jupyterlab/services" "^6.5.0"
+    "@jupyterlab/translation" "^3.5.0"
+    "@jupyterlab/ui-components" "^3.5.0"
+    "@lumino/algorithm" "^1.9.0"
+    "@lumino/coreutils" "^1.11.0"
+    "@lumino/disposable" "^1.10.0"
+    "@lumino/messaging" "^1.10.0"
+    "@lumino/signaling" "^1.10.0"
+    "@lumino/widgets" "^1.33.0"
     csstype "~3.0.3"
     react "^17.0.1"
     typestyle "^2.0.4"
@@ -970,6 +1384,16 @@
     "@jupyterlab/statedb" "^3.2.5"
     "@lumino/coreutils" "^1.5.3"
 
+"@jupyterlab/translation@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/translation/-/translation-3.5.0.tgz#4f8cfd7382009365297df112abb51b7a8d531081"
+  integrity sha512-68Cyc9gVKef/Gr9tx9YisiPEIzXUk+mnM7u9huthq5A0aHh1W0E51CM/m0BwJDBurbY+W7erphy0nSWSEk7vCg==
+  dependencies:
+    "@jupyterlab/coreutils" "^5.5.0"
+    "@jupyterlab/services" "^6.5.0"
+    "@jupyterlab/statedb" "^3.5.0"
+    "@lumino/coreutils" "^1.11.0"
+
 "@jupyterlab/ui-components@^3.2.5":
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/@jupyterlab/ui-components/-/ui-components-3.2.5.tgz#69ab5f6ab27de6f628fe2f820a988434dfaf5cdd"
@@ -989,10 +1413,36 @@
     react-dom "^17.0.1"
     typestyle "^2.0.4"
 
+"@jupyterlab/ui-components@^3.5.0", "@jupyterlab/ui-components@^3.5.0-beta.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/ui-components/-/ui-components-3.5.0.tgz#329d0d0b3db666c041fa1a647af68400909d09e9"
+  integrity sha512-1AIKMUhyLgPYh3R3qvEPRhLKkiVwBtPg571If9UxTvDEJqVwtNTayn47sRsWlOKlueLVwebgEHVSkk2ahxgF6Q==
+  dependencies:
+    "@blueprintjs/core" "^3.36.0"
+    "@blueprintjs/select" "^3.15.0"
+    "@jupyterlab/coreutils" "^5.5.0"
+    "@jupyterlab/translation" "^3.5.0"
+    "@lumino/algorithm" "^1.9.0"
+    "@lumino/commands" "^1.19.0"
+    "@lumino/coreutils" "^1.11.0"
+    "@lumino/disposable" "^1.10.0"
+    "@lumino/signaling" "^1.10.0"
+    "@lumino/virtualdom" "^1.14.0"
+    "@lumino/widgets" "^1.33.0"
+    "@rjsf/core" "^3.1.0"
+    react "^17.0.1"
+    react-dom "^17.0.1"
+    typestyle "^2.0.4"
+
 "@lumino/algorithm@^1.3.3", "@lumino/algorithm@^1.8.0", "@lumino/algorithm@^1.9.1":
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/@lumino/algorithm/-/algorithm-1.9.1.tgz#a870598e031f5ee85e20e77ce7bfffbb0dffd7f5"
   integrity sha512-d0rj7IYRzYj6WbWSrbJbKvrfO4H0NUnXT2yjSWS/sCklpTpSp0IGmndK/X4r6gG+ev5lb5+wBg9ofUDBvoAlAw==
+
+"@lumino/algorithm@^1.9.0", "@lumino/algorithm@^1.9.2":
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/@lumino/algorithm/-/algorithm-1.9.2.tgz#b95e6419aed58ff6b863a51bfb4add0f795141d3"
+  integrity sha512-Z06lp/yuhz8CtIir3PNTGnuk7909eXt4ukJsCzChsGuot2l5Fbs96RJ/FOHgwCedaX74CtxPjXHXoszFbUA+4A==
 
 "@lumino/application@^1.16.0":
   version "1.27.1"
@@ -1010,6 +1460,13 @@
   dependencies:
     "@lumino/algorithm" "^1.9.1"
 
+"@lumino/collections@^1.9.3":
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/@lumino/collections/-/collections-1.9.3.tgz#370dc2d50aa91371288a4f7376bea5a3191fc5dc"
+  integrity sha512-2i2Wf1xnfTgEgdyKEpqM16bcYRIhUOGCDzaVCEZACVG9R1CgYwOe3zfn71slBQOVSjjRgwYrgLXu4MBpt6YK+g==
+  dependencies:
+    "@lumino/algorithm" "^1.9.2"
+
 "@lumino/commands@^1.12.0", "@lumino/commands@^1.17.0", "@lumino/commands@^1.19.1":
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/@lumino/commands/-/commands-1.19.1.tgz#fa124bdbe0acfe3e3e09fce21049b5ee8f71e8f4"
@@ -1023,10 +1480,28 @@
     "@lumino/signaling" "^1.10.1"
     "@lumino/virtualdom" "^1.14.1"
 
+"@lumino/commands@^1.19.0", "@lumino/commands@^1.21.0":
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/@lumino/commands/-/commands-1.21.0.tgz#23cf0b5b1f9b00b0c2960d896726d89dd17bf6b4"
+  integrity sha512-N2LNL5fVNLdD48WEa7yyUtVRc2kIf4YpBojxygzZcMGVaoemLnCnUlw7espB5DTDl+WRO/pi5fkWTnoNvp+8Bg==
+  dependencies:
+    "@lumino/algorithm" "^1.9.2"
+    "@lumino/coreutils" "^1.12.1"
+    "@lumino/disposable" "^1.10.3"
+    "@lumino/domutils" "^1.8.2"
+    "@lumino/keyboard" "^1.8.2"
+    "@lumino/signaling" "^1.11.0"
+    "@lumino/virtualdom" "^1.14.3"
+
 "@lumino/coreutils@^1.10.0", "@lumino/coreutils@^1.11.1", "@lumino/coreutils@^1.5.3":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@lumino/coreutils/-/coreutils-1.11.1.tgz#6d89c6325d7adb5f2179dfe3660f0aec8f3c4546"
   integrity sha512-TbXeYnUChSMN8SmuOwT+bADS3kMhsVaQC0sZie0ZeGaLYxVqvd7NEDRZATDtjdw7QGHK0TwH5+XzuSdNkAXpFw==
+
+"@lumino/coreutils@^1.11.0", "@lumino/coreutils@^1.12.1":
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/@lumino/coreutils/-/coreutils-1.12.1.tgz#79860c9937483ddf6cda87f6c2b9da8eb1a5d768"
+  integrity sha512-JLu3nTHzJk9N8ohZ85u75YxemMrmDzJdNgZztfP7F7T7mxND3YVNCkJG35a6aJ7edu1sIgCjBxOvV+hv27iYvQ==
 
 "@lumino/coreutils@^1.2.0":
   version "1.10.0"
@@ -1063,6 +1538,14 @@
     "@lumino/signaling" "^1.10.1"
     "@lumino/widgets" "^1.30.1"
 
+"@lumino/disposable@^1.10.0", "@lumino/disposable@^1.10.3":
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/@lumino/disposable/-/disposable-1.10.3.tgz#c9778204f997605b00dab342029d488196d4baef"
+  integrity sha512-a+LplaVGuubmM0KcgAK5NCcJxo0vuw020p3r5AaM/uvAtvLHM+po0wqD0Lcz633ERunf+bDdQ+8BcOhrQLPofQ==
+  dependencies:
+    "@lumino/algorithm" "^1.9.2"
+    "@lumino/signaling" "^1.11.0"
+
 "@lumino/disposable@^1.10.1", "@lumino/disposable@^1.4.3", "@lumino/disposable@^1.9.0":
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/@lumino/disposable/-/disposable-1.10.1.tgz#58fddc619cf89335802d168564b76ff5315d5a84"
@@ -1076,6 +1559,11 @@
   resolved "https://registry.yarnpkg.com/@lumino/domutils/-/domutils-1.8.1.tgz#cf118e4eba90c3bf1e3edf7f19cce8846ec7875c"
   integrity sha512-QUVXwmDMIfcHC3yslhmyGK4HYBKaJ3xX5MTwDrjsSX7J7AZ4jwL4zfsxyF9ntdqEKraoJhLQ6BaUBY+Ur1cnYw==
 
+"@lumino/domutils@^1.8.0", "@lumino/domutils@^1.8.2":
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@lumino/domutils/-/domutils-1.8.2.tgz#d15cdbae12bea52852bbc13c4629360f9f05b7f5"
+  integrity sha512-QIpMfkPJrs4GrWBuJf2Sn1fpyVPmvqUUAeD8xAQo8+4V5JAT0vUDLxZ9HijefMgNCi3+Bs8Z3lQwRCrz+cFP1A==
+
 "@lumino/dragdrop@^1.12.0", "@lumino/dragdrop@^1.13.1", "@lumino/dragdrop@^1.7.1":
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/@lumino/dragdrop/-/dragdrop-1.13.1.tgz#a8f8ae4262dcbba4ef85900f6081c90bd47df2b5"
@@ -1084,10 +1572,31 @@
     "@lumino/coreutils" "^1.11.1"
     "@lumino/disposable" "^1.10.1"
 
+"@lumino/dragdrop@^1.13.0", "@lumino/dragdrop@^1.14.3":
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/@lumino/dragdrop/-/dragdrop-1.14.3.tgz#5621d97bcb90ae18b053f56d9c448ccef272d575"
+  integrity sha512-e3/lnc7bSqtdbDyamx+yeLuAECY1XGcczh8Wu66p6nkkohiajLqeNXicvWQd5G+T2xGce6QFkUnqWUcO5KNHOw==
+  dependencies:
+    "@lumino/coreutils" "^1.12.1"
+    "@lumino/disposable" "^1.10.3"
+
 "@lumino/keyboard@^1.2.3", "@lumino/keyboard@^1.7.0", "@lumino/keyboard@^1.8.1":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@lumino/keyboard/-/keyboard-1.8.1.tgz#e7850e2fb973fbb4c6e737ca8d9307f2dc3eb74b"
   integrity sha512-8x0y2ZQtEvOsblpI2gfTgf+gboftusP+5aukKEsgNQtzFl28RezQXEOSVd8iD3K6+Q1MaPQF0OALYP0ASqBjBg==
+
+"@lumino/keyboard@^1.8.2":
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@lumino/keyboard/-/keyboard-1.8.2.tgz#714dbe671f0718f516d1ec23188b31a9ccd82fb2"
+  integrity sha512-Dy+XqQ1wXbcnuYtjys5A0pAqf4SpAFl9NY6owyIhXAo0Va7w3LYp3jgiP1xAaBAwMuUppiUAfrbjrysZuZ625g==
+
+"@lumino/messaging@^1.10.0", "@lumino/messaging@^1.10.3":
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/@lumino/messaging/-/messaging-1.10.3.tgz#b6227bdfc178a8542571625ecb68063691b6af3c"
+  integrity sha512-F/KOwMCdqvdEG8CYAJcBSadzp6aI7a47Fr60zAKGqZATSRRRV41q53iXU7HjFPqQqQIvdn9Z7J32rBEAyQAzww==
+  dependencies:
+    "@lumino/algorithm" "^1.9.2"
+    "@lumino/collections" "^1.9.3"
 
 "@lumino/messaging@^1.10.1", "@lumino/messaging@^1.4.3", "@lumino/messaging@^1.9.0":
   version "1.10.1"
@@ -1114,10 +1623,32 @@
     "@lumino/disposable" "^1.10.1"
     "@lumino/signaling" "^1.10.1"
 
+"@lumino/polling@^1.9.0":
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/@lumino/polling/-/polling-1.11.3.tgz#0b0b9a30b7077834d41df08fb2387260c95cd6e5"
+  integrity sha512-NPda40R/PFwzufuhfEx41g/L3I1K8TEM75QbooL22U+bFRBY9bChOLh+xKXyT2yO30SRLg7F7jaWcwZ01hCVwQ==
+  dependencies:
+    "@lumino/coreutils" "^1.12.1"
+    "@lumino/disposable" "^1.10.3"
+    "@lumino/signaling" "^1.11.0"
+
 "@lumino/properties@^1.2.3", "@lumino/properties@^1.7.0", "@lumino/properties@^1.8.1":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@lumino/properties/-/properties-1.8.1.tgz#47eb8516e92c987dcb2c404db83a258159efec3d"
   integrity sha512-O+CCcAqP64Di32DUZ4Jqq0DtUyE5RJREN5vbkgGZGu+WauJ/RYoiLDe1ubbAeSaHk71OrS60ZBV7QyC8ZaBVsA==
+
+"@lumino/properties@^1.8.0", "@lumino/properties@^1.8.2":
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@lumino/properties/-/properties-1.8.2.tgz#91131f2ca91a902faa138771eb63341db78fc0fd"
+  integrity sha512-EkjI9Cw8R0U+xC9HxdFSu7X1tz1H1vKu20cGvJ2gU+CXlMB1DvoYJCYxCThByHZ+kURTAap4SE5x8HvKwNPbig==
+
+"@lumino/signaling@^1.10.0", "@lumino/signaling@^1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@lumino/signaling/-/signaling-1.11.0.tgz#b61071875a69a02e7b14b779657ebdb099aac676"
+  integrity sha512-c4mfkmwr9RDh/cUF7BFoPj8KdSsmJRfGLt0e2ez4sgnbSX2afeMNQBIi/gKsD4mMmhI5bXa17tVDYQn6ICBXAw==
+  dependencies:
+    "@lumino/algorithm" "^1.9.2"
+    "@lumino/properties" "^1.8.2"
 
 "@lumino/signaling@^1.10.1", "@lumino/signaling@^1.4.3", "@lumino/signaling@^1.9.0":
   version "1.10.1"
@@ -1132,6 +1663,13 @@
   integrity sha512-imIJd/wtRkoR1onEiG5nxPEaIrf70nn4PgD/56ri3/Lo6AJEX2CusF6iIA27GVB8yl/7CxgTHUnzzCwTFPypcA==
   dependencies:
     "@lumino/algorithm" "^1.9.1"
+
+"@lumino/virtualdom@^1.14.0", "@lumino/virtualdom@^1.14.3":
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/@lumino/virtualdom/-/virtualdom-1.14.3.tgz#e490c36ff506d877cf45771d6968e3e26a8919fd"
+  integrity sha512-5joUC1yuxeXbpfbSBm/OR8Mu9HoTo6PDX0RKqzlJ9o97iml7zayFN/ynzcxScKGQAo9iaXOY8uVIvGUT8FnsGw==
+  dependencies:
+    "@lumino/algorithm" "^1.9.2"
 
 "@lumino/widgets@^1.19.0", "@lumino/widgets@^1.19.1", "@lumino/widgets@^1.30.1":
   version "1.30.1"
@@ -1166,6 +1704,23 @@
     "@lumino/properties" "^1.7.0"
     "@lumino/signaling" "^1.9.0"
     "@lumino/virtualdom" "^1.13.0"
+
+"@lumino/widgets@^1.33.0":
+  version "1.35.0"
+  resolved "https://registry.yarnpkg.com/@lumino/widgets/-/widgets-1.35.0.tgz#1d6cf28195996635a8256e2d28edd4fe5dde5f4e"
+  integrity sha512-AFwCCt/4g6+3YwnrxRqjLusuLUidnldkQ+Dims3ZSm8keRtyjhr6ltnhj4KPZ5Nexxb0jmzWYcHHTceYTgU10w==
+  dependencies:
+    "@lumino/algorithm" "^1.9.2"
+    "@lumino/commands" "^1.21.0"
+    "@lumino/coreutils" "^1.12.1"
+    "@lumino/disposable" "^1.10.3"
+    "@lumino/domutils" "^1.8.2"
+    "@lumino/dragdrop" "^1.14.3"
+    "@lumino/keyboard" "^1.8.2"
+    "@lumino/messaging" "^1.10.3"
+    "@lumino/properties" "^1.8.2"
+    "@lumino/signaling" "^1.11.0"
+    "@lumino/virtualdom" "^1.14.3"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -1203,6 +1758,21 @@
   dependencies:
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
+
+"@rjsf/core@^3.1.0":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@rjsf/core/-/core-3.2.1.tgz#8a7b24c9a6f01f0ecb093fdfc777172c12b1b009"
+  integrity sha512-dk8ihvxFbcuIwU7G+HiJbFgwyIvaumPt5g5zfnuC26mwTUPlaDGFXKK2yITp8tJ3+hcwS5zEXtAN9wUkfuM4jA==
+  dependencies:
+    "@types/json-schema" "^7.0.7"
+    ajv "^6.7.0"
+    core-js-pure "^3.6.5"
+    json-schema-merge-allof "^0.6.0"
+    jsonpointer "^5.0.0"
+    lodash "^4.17.15"
+    nanoid "^3.1.23"
+    prop-types "^15.7.2"
+    react-is "^16.9.0"
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -1726,7 +2296,7 @@ ajv-keywords@^3.5.2:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
-ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
+ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5, ajv@^6.7.0:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -2214,6 +2784,25 @@ compression@1.7.4:
     safe-buffer "5.1.2"
     vary "~1.1.2"
 
+compute-gcd@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/compute-gcd/-/compute-gcd-1.2.1.tgz#34d639f3825625e1357ce81f0e456a6249d8c77f"
+  integrity sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==
+  dependencies:
+    validate.io-array "^1.0.3"
+    validate.io-function "^1.0.2"
+    validate.io-integer-array "^1.0.0"
+
+compute-lcm@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/compute-lcm/-/compute-lcm-1.1.2.tgz#9107c66b9dca28cefb22b4ab4545caac4034af23"
+  integrity sha512-OFNPdQAXnQhDSKioX8/XYT6sdUlXwpeMjfd6ApxMJfyZ4GxmLR1xvMERctlYhlHwIiz6CSpBc2+qYKjHGZw4TQ==
+  dependencies:
+    compute-gcd "^1.2.1"
+    validate.io-array "^1.0.3"
+    validate.io-function "^1.0.2"
+    validate.io-integer-array "^1.0.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -2260,6 +2849,11 @@ cookies@0.8.0:
   dependencies:
     depd "~2.0.0"
     keygrip "~1.1.0"
+
+core-js-pure@^3.6.5:
+  version "3.26.1"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.26.1.tgz#653f4d7130c427820dcecd3168b594e8bb095a33"
+  integrity sha512-VVXcDpp/xJ21KdULRq/lXdLzQAtX7+37LzpyfFM973il0tWSsDEoyzG38G14AjTpK9VTfiNM9jnFauq/CpaWGQ==
 
 core-util-is@1.0.2:
   version "1.0.2"
@@ -3965,6 +4559,22 @@ json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
+json-schema-compare@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/json-schema-compare/-/json-schema-compare-0.2.2.tgz#dd601508335a90c7f4cfadb6b2e397225c908e56"
+  integrity sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==
+  dependencies:
+    lodash "^4.17.4"
+
+json-schema-merge-allof@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/json-schema-merge-allof/-/json-schema-merge-allof-0.6.0.tgz#64d48820fec26b228db837475ce3338936bf59a5"
+  integrity sha512-LEw4VMQVRceOPLuGRWcxW5orTTiR9ZAtqTAe4rQUjNADTeR81bezBVFa0MqIwp0YmHIM1KkhSjZM7o+IQhaPbQ==
+  dependencies:
+    compute-lcm "^1.1.0"
+    json-schema-compare "^0.2.2"
+    lodash "^4.17.4"
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
@@ -4017,6 +4627,11 @@ jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
+
+jsonpointer@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-5.0.1.tgz#2110e0af0900fd37467b5907ecd13a7884a1b559"
+  integrity sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==
 
 jsonwebtoken@8.5.1:
   version "8.5.1"
@@ -4310,7 +4925,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@4, lodash@4.17.21, lodash@^4.17.19, lodash@^4.17.4:
+lodash@4, lodash@4.17.21, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -4385,6 +5000,11 @@ marked@2.1.3, marked@^2.0.0, marked@^2.0.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/marked/-/marked-2.1.3.tgz#bd017cef6431724fd4b27e0657f5ceb14bff3753"
   integrity sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==
+
+marked@^4.0.17:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.2.2.tgz#1d2075ad6cdfe42e651ac221c32d949a26c0672a"
+  integrity sha512-JjBTFTAvuTgANXx82a5vzK9JLSMoV6V3LBVn4Uhdso6t7vXrGx7g1Cd2r6NYSsxrYbQGFCMqBDhFHyK5q2UvcQ==
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -4582,6 +5202,11 @@ mv@2.1.1:
     mkdirp "~0.5.1"
     ncp "~2.0.0"
     rimraf "~2.4.0"
+
+nanoid@^3.1.23:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
+  integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
 
 nanoid@^3.1.30:
   version "3.3.1"
@@ -5103,6 +5728,15 @@ prop-types@^15.6.1, prop-types@^15.6.2:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
+prop-types@^15.7.2:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
+
 proxy-addr@~2.0.5, proxy-addr@~2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
@@ -5238,7 +5872,7 @@ react-dom@^17.0.1:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
-react-is@^16.13.1:
+react-is@^16.13.1, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -6330,6 +6964,36 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+validate.io-array@^1.0.3:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/validate.io-array/-/validate.io-array-1.0.6.tgz#5b5a2cafd8f8b85abb2f886ba153f2d93a27774d"
+  integrity sha512-DeOy7CnPEziggrOO5CZhVKJw6S3Yi7e9e65R1Nl/RTN1vTQKnzjfvks0/8kQ40FP/dsjRAOd4hxmJ7uLa6vxkg==
+
+validate.io-function@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/validate.io-function/-/validate.io-function-1.0.2.tgz#343a19802ed3b1968269c780e558e93411c0bad7"
+  integrity sha512-LlFybRJEriSuBnUhQyG5bwglhh50EpTL2ul23MPIuR1odjO7XaMLFV8vHGwp7AZciFxtYOeiSCT5st+XSPONiQ==
+
+validate.io-integer-array@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz#2cabde033293a6bcbe063feafe91eaf46b13a089"
+  integrity sha512-mTrMk/1ytQHtCY0oNO3dztafHYyGU88KL+jRxWuzfOmQb+4qqnWmI+gykvGp8usKZOM0H7keJHEbRaFiYA0VrA==
+  dependencies:
+    validate.io-array "^1.0.3"
+    validate.io-integer "^1.0.4"
+
+validate.io-integer@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/validate.io-integer/-/validate.io-integer-1.0.5.tgz#168496480b95be2247ec443f2233de4f89878068"
+  integrity sha512-22izsYSLojN/P6bppBqhgUDjCkr5RY2jd+N2a3DCAUey8ydvrZ/OkGvFPR7qfOpwR2LC5p4Ngzxz36g5Vgr/hQ==
+  dependencies:
+    validate.io-number "^1.0.3"
+
+validate.io-number@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/validate.io-number/-/validate.io-number-1.0.3.tgz#f63ffeda248bf28a67a8d48e0e3b461a1665baf8"
+  integrity sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg==
 
 validator@13.7.0:
   version "13.7.0"


### PR DESCRIPTION
### References

This PR should unblock #45 and fix #40

### Description

- improves the first load time (2.3 MB less data loaded)
- packages do not get pre-loaded, so if they are missing they no longer break the extension
- even without the fully deferred loading, f5a32fa0c24cde5eb0ea6a856fe318e93b2b7483 already protects from extension going defunct in absence of any module as the async webpack import errors will pop up in the console at a later time without preventing the extension from loading
- allows to use the extension in latest JupyterLab 4.0 alpha (<s>note: the editor does not get populated with an example due to API changes, but otherwise it works now</s> fixed in 9a9c62d9d37081a650efc1217035a10c21702917)

Binder https://mybinder.org/v2/gh/krassowski/jupyterlab-plugin-playground/async-imports?urlpath=lab

### Other code changes
- adds `@jupyterlab/cell-toolbar` (added in 3.4) and `@jupyterlab/collaboration` (getting added in 3.6) packages to allow experimenting with them in the playground; this is backward-compatible (you just cannot use them in earlier versions)
- adds the auto-generated `modules.ts` to lint ignores to simplify updates

### Breaking changes

- `modules: Record<string, IModule>` → `function loadKnownModule(name: string): Promise<IModule | null>`