### PR TITLE
Add `@jupyter/docprovider`

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "typescript": "~5.7.3"
   },
   "devDependencies": {
+    "@jupyter/collaborative-drive": "^4.2.1",
     "@jupyter/docprovider": "^4.1.1",
     "@jupyterlab/builder": "^4.5.5",
     "@jupyterlab/cell-toolbar": "^4.5.5",

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -23,6 +23,8 @@ export function loadKnownModule(name: string): Promise<IModule | null> {
       return import('@jupyterlab/coreutils') as any;
     case '@jupyterlab/debugger':
       return import('@jupyterlab/debugger') as any;
+    case '@jupyter/collaborative-drive':
+      return import('@jupyter/collaborative-drive') as any;
     case '@jupyterlab/docmanager':
       return import('@jupyterlab/docmanager') as any;
     case '@jupyter/docprovider':

--- a/yarn.lock
+++ b/yarn.lock
@@ -1371,6 +1371,7 @@ __metadata:
   resolution: "@jupyterlab/plugin-playground@workspace:."
   dependencies:
     "@jupyter-widgets/base": ^6.0.0
+    "@jupyter/collaborative-drive": ^4.2.1
     "@jupyter/docprovider": ^4.1.1
     "@jupyterlab/application": ^4.5.5
     "@jupyterlab/apputils": ^4.6.5


### PR DESCRIPTION
closes #66 
Add `@jupyter/docprovider` as a known module from `jupyter-collaboration`