### PR TITLE
Downgrade `packageManager` from yarn@3.6.4 to yarn@3.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "type": "git",
     "url": "https://github.com/jupyterlab/jupyterlab-plugin-playground.git"
   },
-  "packageManager": "yarn@3.6.4",
+  "packageManager": "yarn@3.5.0",
   "scripts": {
     "build": "jlpm run build:lib && jlpm run build:labextension:dev",
     "build:prod": "jlpm run clean && jlpm run build:lib && jlpm run build:labextension",


### PR DESCRIPTION
Noticed in https://github.com/jupyterlab/jupyterlab-plugin-playground/pull/73 that wrong version of yarn patch gets applied which makes the depandabot PRs fail. Downgrading to version matching `jlpm` in JupyterLab 4.0