### PR TITLE
Update repo references to jupyterlab/plugin-playground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,28 +4,28 @@
 
 ## 0.4.0
 
-([Full Changelog](https://github.com/jupyterlab/jupyterlab-plugin-playground/compare/v0.3.0...d2927797381a74fc731f2e929302e9ae328bece6))
+([Full Changelog](https://github.com/jupyterlab/plugin-playground/compare/v0.3.0...d2927797381a74fc731f2e929302e9ae328bece6))
 
 ### Enhancements made
 
-- Transpile (optional) TypeScript, support imports (package and relative) and schema [#28](https://github.com/jupyterlab/jupyterlab-plugin-playground/pull/28) ([@krassowski](https://github.com/krassowski))
-- Add LSP to the Binder image [#26](https://github.com/jupyterlab/jupyterlab-plugin-playground/pull/26) ([@krassowski](https://github.com/krassowski))
+- Transpile (optional) TypeScript, support imports (package and relative) and schema [#28](https://github.com/jupyterlab/plugin-playground/pull/28) ([@krassowski](https://github.com/krassowski))
+- Add LSP to the Binder image [#26](https://github.com/jupyterlab/plugin-playground/pull/26) ([@krassowski](https://github.com/krassowski))
 
 ### Maintenance and upkeep improvements
 
-- Use `maintainer-tools` actions [#32](https://github.com/jupyterlab/jupyterlab-plugin-playground/pull/32) ([@jtpio](https://github.com/jtpio))
-- Bump nanoid from 3.1.29 to 3.2.0 [#31](https://github.com/jupyterlab/jupyterlab-plugin-playground/pull/31) ([@dependabot](https://github.com/dependabot))
-- Fix CI [#17](https://github.com/jupyterlab/jupyterlab-plugin-playground/pull/17) ([@jtpio](https://github.com/jtpio))
+- Use `maintainer-tools` actions [#32](https://github.com/jupyterlab/plugin-playground/pull/32) ([@jtpio](https://github.com/jtpio))
+- Bump nanoid from 3.1.29 to 3.2.0 [#31](https://github.com/jupyterlab/plugin-playground/pull/31) ([@dependabot](https://github.com/dependabot))
+- Fix CI [#17](https://github.com/jupyterlab/plugin-playground/pull/17) ([@jtpio](https://github.com/jtpio))
 
 ### Other merged PRs
 
-- Use title case in label [#23](https://github.com/jupyterlab/jupyterlab-plugin-playground/pull/23) ([@krassowski](https://github.com/krassowski))
-- Fix example in readme [#19](https://github.com/jupyterlab/jupyterlab-plugin-playground/pull/19) ([@jasongrout](https://github.com/jasongrout))
+- Use title case in label [#23](https://github.com/jupyterlab/plugin-playground/pull/23) ([@krassowski](https://github.com/krassowski))
+- Fix example in readme [#19](https://github.com/jupyterlab/plugin-playground/pull/19) ([@jasongrout](https://github.com/jasongrout))
 
 ### Contributors to this release
 
-([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab-plugin-playground/graphs/contributors?from=2021-10-15&to=2022-03-24&type=c))
+([GitHub contributors page for this release](https://github.com/jupyterlab/plugin-playground/graphs/contributors?from=2021-10-15&to=2022-03-24&type=c))
 
-[@dependabot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab-plugin-playground+involves%3Adependabot+updated%3A2021-10-15..2022-03-24&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab-plugin-playground+involves%3Ajasongrout+updated%3A2021-10-15..2022-03-24&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab-plugin-playground+involves%3Ajtpio+updated%3A2021-10-15..2022-03-24&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab-plugin-playground+involves%3Akrassowski+updated%3A2021-10-15..2022-03-24&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab-plugin-playground+involves%3Awelcome+updated%3A2021-10-15..2022-03-24&type=Issues)
+[@dependabot](https://github.com/search?q=repo%3Ajupyterlab%2Fplugin-playground+involves%3Adependabot+updated%3A2021-10-15..2022-03-24&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Fplugin-playground+involves%3Ajasongrout+updated%3A2021-10-15..2022-03-24&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fplugin-playground+involves%3Ajtpio+updated%3A2021-10-15..2022-03-24&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Fplugin-playground+involves%3Akrassowski+updated%3A2021-10-15..2022-03-24&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fplugin-playground+involves%3Awelcome+updated%3A2021-10-15..2022-03-24&type=Issues)
 
 <!-- <END NEW CHANGELOG ENTRY> -->

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # JupyterLab Plugin Playground
 
-[![Github Actions Status](https://github.com/jupyterlab/jupyterlab-plugin-playground/workflows/Build/badge.svg)](https://github.com/jupyterlab/jupyterlab-plugin-playground/actions/workflows/build.yml)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlab/jupyterlab-plugin-playground/main?urlpath=lab)
+[![Github Actions Status](https://github.com/jupyterlab/plugin-playground/workflows/Build/badge.svg)](https://github.com/jupyterlab/plugin-playground/actions/workflows/build.yml)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlab/plugin-playground/main?urlpath=lab)
 [![JupyterLite](https://jupyterlite.rtfd.io/en/latest/_static/badge-launch.svg)](https://jupyterlab-plugin-playground.readthedocs.io/en/latest/lite/lab/)
 
 A JupyterLab extension to write and load simple JupyterLab plugins inside JupyterLab.

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "jupyterlab",
     "jupyterlab-extension"
   ],
-  "homepage": "https://github.com/jupyterlab/jupyterlab-plugin-playground",
+  "homepage": "https://github.com/jupyterlab/plugin-playground",
   "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab-plugin-playground/issues"
+    "url": "https://github.com/jupyterlab/plugin-playground/issues"
   },
   "license": "BSD-3-Clause",
   "author": {
@@ -26,7 +26,7 @@
   "style": "style/index.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab-plugin-playground.git"
+    "url": "https://github.com/jupyterlab/plugin-playground.git"
   },
   "packageManager": "yarn@3.5.0",
   "scripts": {


### PR DESCRIPTION
closes #18 

Updates outdated repo links after the rename to jupyterlab/plugin-playground.
* Updated GitHub/Binder links in README.md
* Updated homepage, bugs, and repository URLs in package.json
* Updated repo, PR, contributors, and encoded search links in CHANGELOG.md

No functional code changes.