### PR TITLE
Add direct and AI-assisted command insertion modes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,13 @@ jobs:
     - name: Install dependencies
       run: python -m pip install -U "jupyterlab>=4,<5"
 
+    - name: Check lockfiles are deduplicated
+      run: |
+        set -eux
+        jlpm dedupe --check
+        cd ui-tests
+        jlpm dedupe --check
+
     - name: Lint the extension
       run: |
         set -eux

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This extension provides a new command, `Load Current File As Extension`, availab
 
 It also adds a single right sidebar panel with two collapsible sections:
 
-- **Extension Points**: token string IDs and command IDs, with a `Tokens` / `Commands` switch. Tokens support search, copy, and import actions. Commands support search and copy actions.
+- **Extension Points**: token string IDs and command IDs, with a `Tokens` / `Commands` switch. Tokens support search, copy, and import actions. Commands support search, copy, and insert-at-cursor actions.
 - **Extension Examples**: discovered examples from a local checkout of [`jupyterlab/extension-examples`](https://github.com/jupyterlab/extension-examples), so you can open them directly from the panel.
 
 If examples are missing:
@@ -138,6 +138,24 @@ Plugin Playground supports AI-assisted extension prototyping in both JupyterLite
 
 - [JupyterLite AI documentation](https://jupyterlite-ai.readthedocs.io/en/latest/)
 - [Plugin authoring skill for agents](_agents/skills/plugin-authoring/SKILL.md)
+
+### Command Insert Modes (Default + AI Prompt)
+
+The `+` action in the `Commands` tab depends on mode:
+
+- `Insert in selection` inserts:
+
+```ts
+app.commands.execute('<command-id>');
+```
+
+at the active cursor position.
+
+- `Prompt AI to insert` does not insert directly. It opens JupyterLite AI chat and prefills a prompt with file context so AI can choose the best insertion location before you submit.
+
+The sidebar remembers your last-used command insert mode in:
+
+- `commandInsertDefaultMode` (`insert` or `ai`, `insert` by default)
 
 ### Commands for AI Agents and Automation
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@codemirror/state": "^6.5.4",
     "@codemirror/view": "^6.39.16",
     "@jupyter-widgets/base": "^6.0.0",
+    "@jupyter/chat": "^0.21.0",
     "@jupyterlab/application": "^4.5.5",
     "@jupyterlab/apputils": "^4.6.5",
     "@jupyterlab/codemirror": "^4.5.5",

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -37,6 +37,13 @@
       "default": false,
       "type": "boolean"
     },
+    "commandInsertDefaultMode": {
+      "title": "Default command insertion mode",
+      "description": "The default action used by the + button in the Commands tab. Use \"insert\" to insert command execution directly at cursor, or \"ai\" to open JupyterLite AI chat with a prefilled prompt so AI can place the insertion in context.",
+      "default": "insert",
+      "type": "string",
+      "enum": ["insert", "ai"]
+    },
     "plugins": {
       "title": "Plugins",
       "description": "List of strings of plugin text to load automatically. Line breaks are encoded as '\\n'",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2322,23 +2322,25 @@ class PluginPlayground {
     });
     this.app.shell.activateById(JUPYTERLITE_AI_CHAT_PANEL_ID);
 
-    const inputModel = this._requireJupyterLiteAIChatInputModel();
+    const inputModel = await this._requireJupyterLiteAIChatInputModel();
     inputModel.value = prompt;
     inputModel.focus();
   }
 
-  private _requireJupyterLiteAIChatInputModel(): {
+  private async _requireJupyterLiteAIChatInputModel(): Promise<{
     value: string;
     focus: () => void;
-  } {
-    if (!this.chatTracker) {
+  }> {
+    const chatTracker =
+      this.chatTracker ?? (await this.app.resolveOptionalService(IChatTracker));
+    if (!chatTracker) {
       throw new Error(
         `${JUPYTERLITE_AI_INSTALL_HINT} Missing service: "@jupyter/chat:IChatTracker".`
       );
     }
 
     const chatWidget =
-      this.chatTracker.currentWidget ?? this.chatTracker.find(() => true);
+      chatTracker.currentWidget ?? chatTracker.find(() => true);
     if (!chatWidget) {
       throw new Error(
         `${JUPYTERLITE_AI_INSTALL_HINT} Chat tracker has no active widgets.`

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,7 @@ import {
   CommandCompletionProvider,
   getCommandArgumentCount,
   getCommandArgumentDocumentation,
+  type ICommandArgumentDocumentation,
   getCommandRecords
 } from './command-completion';
 
@@ -2304,11 +2305,16 @@ class PluginPlayground {
     appVariableName: string | null;
   }): Promise<void> {
     const { editorWidget } = options.activeEditor;
+    const commandArguments = await getCommandArgumentDocumentation(
+      this.app,
+      options.commandId
+    ).catch(() => null);
     const prompt = this._buildCommandInsertAIPrompt({
       commandId: options.commandId,
       path: editorWidget.context.path,
       suggestedSnippet: options.suggestedSnippet,
-      appVariableName: options.appVariableName
+      appVariableName: options.appVariableName,
+      commandArguments
     });
 
     if (!this.app.commands.hasCommand(JUPYTERLITE_AI_OPEN_CHAT_COMMAND)) {
@@ -2390,20 +2396,49 @@ class PluginPlayground {
     path: string;
     suggestedSnippet: string;
     appVariableName: string | null;
+    commandArguments: ICommandArgumentDocumentation | null;
   }): string {
     const normalizedPath = ContentUtils.normalizeContentsPath(options.path);
     const appContextInstruction = options.appVariableName
       ? `Use the activate() app variable: ${options.appVariableName}.`
       : 'If app is missing, add JupyterFrontEnd import and declare activate(app: JupyterFrontEnd, ...).';
+    const commandArgumentsInstruction =
+      this._buildCommandArgumentsPromptSection(options.commandArguments);
     return [
       'Insert this command execution in the best location in this file.',
       'Keep exactly one final execute() call for this command.',
       'Use the currently open editor content as the source of truth.',
       appContextInstruction,
+      commandArgumentsInstruction,
       `Command ID: ${options.commandId}`,
       `Suggested command call: ${options.suggestedSnippet}`,
       `File: ${normalizedPath || '(unsaved)'}`
-    ].join('\n');
+    ]
+      .filter(Boolean)
+      .join('\n');
+  }
+
+  private _buildCommandArgumentsPromptSection(
+    commandArguments: ICommandArgumentDocumentation | null
+  ): string {
+    if (!commandArguments) {
+      return '';
+    }
+
+    const sections: string[] = [];
+    if (commandArguments.usage) {
+      sections.push(`Usage:\n${commandArguments.usage}`);
+    }
+    if (commandArguments.args) {
+      sections.push(
+        `Arguments Schema: ${JSON.stringify(commandArguments.args)}`
+      );
+    }
+    if (sections.length === 0) {
+      return '';
+    }
+
+    return `Command Arguments:\n${sections.join('\n\n')}`;
   }
 
   private _commandExecutionSnippet(

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { FileEditor, IEditorTracker } from '@jupyterlab/fileeditor';
 
 import { ILauncher } from '@jupyterlab/launcher';
 import { IMainMenu } from '@jupyterlab/mainmenu';
+import { IChatTracker } from '@jupyter/chat';
 
 import {
   checkIcon,
@@ -303,6 +304,7 @@ class PluginPlayground {
     protected editorTracker: IEditorTracker,
     launcher: ILauncher | null,
     protected documentManager: IDocumentManager | null,
+    protected chatTracker: IChatTracker | null,
     protected settings: ISettingRegistry.ISettings,
     protected requirejs: IRequireJS,
     toolbarWidgetRegistry: IToolbarWidgetRegistry
@@ -2329,37 +2331,45 @@ class PluginPlayground {
     value: string;
     focus: () => void;
   } {
-    const sideWidgets = [
-      ...Array.from(this.app.shell.widgets('left')),
-      ...Array.from(this.app.shell.widgets('right'))
-    ];
-    const chatPanel = sideWidgets.find(
-      widget => widget.id === JUPYTERLITE_AI_CHAT_PANEL_ID
-    ) as
-      | {
-          current?: {
-            model?: { input?: unknown };
-          };
-        }
-      | undefined;
-    if (!chatPanel) {
+    if (!this.chatTracker) {
       throw new Error(
-        `${JUPYTERLITE_AI_INSTALL_HINT} Missing panel: "${JUPYTERLITE_AI_CHAT_PANEL_ID}".`
+        `${JUPYTERLITE_AI_INSTALL_HINT} Missing service: "@jupyter/chat:IChatTracker".`
       );
     }
 
-    const candidate = chatPanel.current?.model?.input;
-    if (
+    const chatWidget =
+      this.chatTracker.currentWidget ?? this.chatTracker.find(() => true);
+    if (!chatWidget) {
+      throw new Error(
+        `${JUPYTERLITE_AI_INSTALL_HINT} Chat tracker has no active widgets.`
+      );
+    }
+
+    const inputModel = (
+      chatWidget as {
+        model?: {
+          input?: unknown;
+        };
+      }
+    ).model?.input;
+    if (this._isJupyterLiteAIChatInputModel(inputModel)) {
+      return inputModel;
+    }
+    throw new Error(JUPYTERLITE_AI_PROVIDER_SETUP_HINT);
+  }
+
+  private _isJupyterLiteAIChatInputModel(candidate: unknown): candidate is {
+    value: string;
+    focus: () => void;
+  } {
+    return !!(
       candidate &&
       typeof candidate === 'object' &&
       'value' in candidate &&
       typeof candidate.value === 'string' &&
       'focus' in candidate &&
       typeof candidate.focus === 'function'
-    ) {
-      return candidate as { value: string; focus: () => void };
-    }
-    throw new Error(JUPYTERLITE_AI_PROVIDER_SETUP_HINT);
+    );
   }
 
   private _buildCommandInsertAIPrompt(options: {
@@ -2695,7 +2705,12 @@ const mainPlugin: JupyterFrontEndPlugin<IPluginPlayground> = {
     IEditorTracker,
     IToolbarWidgetRegistry
   ],
-  optional: [ICompletionProviderManager, ILauncher, IDocumentManager],
+  optional: [
+    ICompletionProviderManager,
+    ILauncher,
+    IDocumentManager,
+    IChatTracker
+  ],
   activate: (
     app: JupyterFrontEnd,
     settingRegistry: ISettingRegistry,
@@ -2704,7 +2719,8 @@ const mainPlugin: JupyterFrontEndPlugin<IPluginPlayground> = {
     toolbarWidgetRegistry: IToolbarWidgetRegistry,
     completionManager: ICompletionProviderManager | null,
     launcher: ILauncher | null,
-    documentManager: IDocumentManager | null
+    documentManager: IDocumentManager | null,
+    chatTracker: IChatTracker | null
   ): IPluginPlayground => {
     if (completionManager) {
       completionManager.registerProvider(new CommandCompletionProvider(app));
@@ -2727,6 +2743,7 @@ const mainPlugin: JupyterFrontEndPlugin<IPluginPlayground> = {
         editorTracker,
         launcher,
         documentManager,
+        chatTracker,
         settings,
         requirejs,
         toolbarWidgetRegistry

--- a/src/index.ts
+++ b/src/index.ts
@@ -264,6 +264,8 @@ const JUPYTERLITE_AI_OPEN_CHAT_COMMAND = '@jupyterlite/ai:open-chat';
 const JUPYTERLITE_AI_CHAT_PANEL_ID = '@jupyterlite/ai:chat-panel';
 const JUPYTERLITE_AI_INSTALL_HINT =
   'JupyterLite AI is unavailable. Install the "jupyterlite-ai" extension and reload.';
+const JUPYTERLITE_AI_PROVIDER_SETUP_HINT =
+  'JupyterLite AI provider is not configured. Configure a provider and try again.';
 const DEFAULT_COMMAND_INSERT_MODE: CommandInsertMode = 'insert';
 const ARCHIVE_EXCLUDED_DIRECTORIES = new Set([
   '.git',
@@ -2194,12 +2196,14 @@ class PluginPlayground {
         'Failed to prefill JupyterLite AI prompt for insertion.',
         error
       );
-      Notification.warning(
-        `Could not prefill AI insertion prompt for "${commandId}": ${message}`,
-        {
-          autoClose: 5000
-        }
-      );
+      const warningMessage =
+        message === JUPYTERLITE_AI_PROVIDER_SETUP_HINT ||
+        message.startsWith(JUPYTERLITE_AI_INSTALL_HINT)
+          ? message
+          : `Could not prefill AI insertion prompt for "${commandId}": ${message}`;
+      Notification.warning(warningMessage, {
+        autoClose: 5000
+      });
     }
   }
 
@@ -2212,18 +2216,43 @@ class PluginPlayground {
   ): void {
     const { editorWidget, sourceModel } = activeEditor;
     const editor = editorWidget.content.editor;
+    const originalCursorPosition = editor.getCursorPosition();
+    const originalInsertionOffset = editor.getOffsetAt(originalCursorPosition);
     const originalSource = sourceModel.sharedModel.getSource();
-    const activateAppContext = ensurePluginActivateAppContext(originalSource);
-    if (activateAppContext.source !== originalSource) {
+    let cursorMarker = '__plugin_playground_cursor_marker__';
+    while (originalSource.includes(cursorMarker)) {
+      cursorMarker = `${cursorMarker}_`;
+    }
+    const sourceWithCursorMarker = `${originalSource.slice(
+      0,
+      originalInsertionOffset
+    )}${cursorMarker}${originalSource.slice(originalInsertionOffset)}`;
+
+    const activateAppContext = ensurePluginActivateAppContext(
+      sourceWithCursorMarker
+    );
+    const markerOffset = activateAppContext.source.indexOf(cursorMarker);
+    const sourceWithoutMarker =
+      markerOffset === -1
+        ? activateAppContext.source
+        : `${activateAppContext.source.slice(
+            0,
+            markerOffset
+          )}${activateAppContext.source.slice(
+            markerOffset + cursorMarker.length
+          )}`;
+    if (sourceWithoutMarker !== originalSource) {
       sourceModel.sharedModel.updateSource(
         0,
         originalSource.length,
-        activateAppContext.source
+        sourceWithoutMarker
       );
     }
 
-    const cursorPosition = editor.getCursorPosition();
-    const insertionOffset = editor.getOffsetAt(cursorPosition);
+    const insertionOffset =
+      markerOffset === -1 ? originalInsertionOffset : markerOffset;
+    const cursorPosition =
+      editor.getPositionAt(insertionOffset) ?? editor.getCursorPosition();
     const insertText = this._commandExecutionSnippet(
       commandId,
       activateAppContext.appVariableName
@@ -2285,16 +2314,21 @@ class PluginPlayground {
     await this.app.commands.execute(JUPYTERLITE_AI_OPEN_CHAT_COMMAND, {
       area: 'side'
     });
+    this.app.shell.activateById(JUPYTERLITE_AI_CHAT_PANEL_ID);
 
     const inputModel = this._requireJupyterLiteAIChatInputModel();
-    this._setJupyterLiteAIInputPrompt(inputModel, prompt);
+    inputModel.value = prompt;
+    inputModel.focus();
   }
 
   private _requireJupyterLiteAIChatInputModel(): {
     value: string;
     focus: () => void;
   } {
-    const sideWidgets = Array.from(this.app.shell.widgets('left'));
+    const sideWidgets = [
+      ...Array.from(this.app.shell.widgets('left')),
+      ...Array.from(this.app.shell.widgets('right'))
+    ];
     const chatPanel = sideWidgets.find(
       widget => widget.id === JUPYTERLITE_AI_CHAT_PANEL_ID
     ) as
@@ -2304,8 +2338,13 @@ class PluginPlayground {
           };
         }
       | undefined;
+    if (!chatPanel) {
+      throw new Error(
+        `${JUPYTERLITE_AI_INSTALL_HINT} Missing panel: "${JUPYTERLITE_AI_CHAT_PANEL_ID}".`
+      );
+    }
 
-    const candidate = chatPanel?.current?.model?.input;
+    const candidate = chatPanel.current?.model?.input;
     if (
       candidate &&
       typeof candidate === 'object' &&
@@ -2316,17 +2355,7 @@ class PluginPlayground {
     ) {
       return candidate as { value: string; focus: () => void };
     }
-    throw new Error(
-      'Opened JupyterLite AI chat, but could not access chat input model.'
-    );
-  }
-
-  private _setJupyterLiteAIInputPrompt(
-    inputModel: { value: string; focus: () => void },
-    prompt: string
-  ): void {
-    inputModel.value = prompt;
-    inputModel.focus();
+    throw new Error(JUPYTERLITE_AI_PROVIDER_SETUP_HINT);
   }
 
   private _buildCommandInsertAIPrompt(options: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -585,6 +585,7 @@ class PluginPlayground {
         openDocumentationLink: this._openDocumentationLink.bind(this),
         onInsertImport: this._insertTokenImport.bind(this),
         isImportEnabled: this._canInsertImport.bind(this),
+        onSetCommandInsertMode: this._setCommandInsertMode.bind(this),
         onInsertCommand: this._insertCommandExecution.bind(this),
         getCommandInsertMode: () => this._commandInsertMode,
         isCommandInsertEnabled: this._hasEditableEditor.bind(this)
@@ -2151,18 +2152,7 @@ class PluginPlayground {
     commandId: string,
     mode: CommandInsertMode
   ): Promise<void> {
-    if (this._commandInsertMode !== mode) {
-      this._commandInsertMode = mode;
-      this._tokenSidebar?.update();
-      try {
-        await this.settings.set(COMMAND_INSERT_DEFAULT_MODE_SETTING, mode);
-      } catch (error) {
-        console.warn(
-          `Failed to persist "${COMMAND_INSERT_DEFAULT_MODE_SETTING}" setting.`,
-          error
-        );
-      }
-    }
+    await this._setCommandInsertMode(mode);
 
     const activeEditor = await this._requireEditableEditor(
       'Open a text editor tab to insert command execution.'
@@ -2204,6 +2194,22 @@ class PluginPlayground {
       Notification.warning(warningMessage, {
         autoClose: 5000
       });
+    }
+  }
+
+  private async _setCommandInsertMode(mode: CommandInsertMode): Promise<void> {
+    if (this._commandInsertMode === mode) {
+      return;
+    }
+    this._commandInsertMode = mode;
+    this._tokenSidebar?.update();
+    try {
+      await this.settings.set(COMMAND_INSERT_DEFAULT_MODE_SETTING, mode);
+    } catch (error) {
+      console.warn(
+        `Failed to persist "${COMMAND_INSERT_DEFAULT_MODE_SETTING}" setting.`,
+        error
+      );
     }
   }
 
@@ -2295,10 +2301,8 @@ class PluginPlayground {
     suggestedSnippet: string;
     appVariableName: string | null;
   }): Promise<void> {
-    const { editorWidget, sourceModel } = options.activeEditor;
-    const source = sourceModel.sharedModel.getSource();
+    const { editorWidget } = options.activeEditor;
     const prompt = this._buildCommandInsertAIPrompt({
-      source,
       commandId: options.commandId,
       path: editorWidget.context.path,
       suggestedSnippet: options.suggestedSnippet,
@@ -2359,16 +2363,11 @@ class PluginPlayground {
   }
 
   private _buildCommandInsertAIPrompt(options: {
-    source: string;
     commandId: string;
     path: string;
     suggestedSnippet: string;
     appVariableName: string | null;
   }): string {
-    const lines = options.source.split(/\r?\n/);
-    const context = lines
-      .map((line, index) => `${index + 1}: ${line}`)
-      .join('\n');
     const normalizedPath = ContentUtils.normalizeContentsPath(options.path);
     const appContextInstruction = options.appVariableName
       ? `Use the activate() app variable: ${options.appVariableName}.`
@@ -2376,12 +2375,11 @@ class PluginPlayground {
     return [
       'Insert this command execution in the best location in this file.',
       'Keep exactly one final execute() call for this command.',
+      'Use the currently open editor content as the source of truth.',
       appContextInstruction,
       `Command ID: ${options.commandId}`,
       `Suggested command call: ${options.suggestedSnippet}`,
-      `File: ${normalizedPath || '(unsaved)'}`,
-      'Context:',
-      context
+      `File: ${normalizedPath || '(unsaved)'}`
     ].join('\n');
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2325,6 +2325,17 @@ class PluginPlayground {
     const inputModel = await this._requireJupyterLiteAIChatInputModel();
     inputModel.value = prompt;
     inputModel.focus();
+    window.requestAnimationFrame(() => {
+      const activeElement = document.activeElement;
+      if (
+        activeElement instanceof HTMLTextAreaElement ||
+        activeElement instanceof HTMLInputElement
+      ) {
+        const cursorIndex = activeElement.value.length;
+        activeElement.setSelectionRange(cursorIndex, cursorIndex);
+        activeElement.scrollTop = activeElement.scrollHeight;
+      }
+    });
   }
 
   private async _requireJupyterLiteAIChatInputModel(): Promise<{

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ import { ImportResolver } from './resolver';
 import { IRequireJS, RequireJSLoader } from './requirejs';
 
 import {
+  type CommandInsertMode,
   filterCommandRecords,
   filterTokenRecords,
   TokenSidebar
@@ -80,6 +81,8 @@ import {
 
 import { ContentUtils } from './contents';
 import {
+  ensurePluginActivateAppContext,
+  findPluginActivateAppParameterName,
   insertImportStatement,
   insertTokenDependency,
   parseTokenReference
@@ -252,10 +255,16 @@ const CREATE_PLUGIN_ARGS_SCHEMA = {
 const LOAD_ON_SAVE_TOGGLE_TOOLBAR_ITEM = 'plugin-playground-load-on-save';
 const LOAD_ON_SAVE_CHECKBOX_LABEL = 'Auto Load on Save';
 const LOAD_ON_SAVE_SETTING = 'loadOnSave';
+const COMMAND_INSERT_DEFAULT_MODE_SETTING = 'commandInsertDefaultMode';
 const LOAD_ON_SAVE_ENABLED_DESCRIPTION =
   'Toggle auto-loading this file as an extension on save';
 const LOAD_ON_SAVE_DISABLED_DESCRIPTION =
   'Auto load on save is available for JavaScript and TypeScript files';
+const JUPYTERLITE_AI_OPEN_CHAT_COMMAND = '@jupyterlite/ai:open-chat';
+const JUPYTERLITE_AI_CHAT_PANEL_ID = '@jupyterlite/ai:chat-panel';
+const JUPYTERLITE_AI_INSTALL_HINT =
+  'JupyterLite AI is unavailable. Install the "jupyterlite-ai" extension and reload.';
+const DEFAULT_COMMAND_INSERT_MODE: CommandInsertMode = 'insert';
 const ARCHIVE_EXCLUDED_DIRECTORIES = new Set([
   '.git',
   '.ipynb_checkpoints',
@@ -573,7 +582,10 @@ class PluginPlayground {
         discoverKnownModules: force => discoverFederatedKnownModules({ force }),
         openDocumentationLink: this._openDocumentationLink.bind(this),
         onInsertImport: this._insertTokenImport.bind(this),
-        isImportEnabled: this._canInsertImport.bind(this)
+        isImportEnabled: this._canInsertImport.bind(this),
+        onInsertCommand: this._insertCommandExecution.bind(this),
+        getCommandInsertMode: () => this._commandInsertMode,
+        isCommandInsertEnabled: this._hasEditableEditor.bind(this)
       });
       this._tokenSidebar = tokenSidebar;
       tokenSidebar.id = 'jp-plugin-token-sidebar';
@@ -646,6 +658,7 @@ class PluginPlayground {
       settings.changed.connect(updatedSettings => {
         this.settings = updatedSettings;
         this._updateSettings(requirejs, updatedSettings);
+        tokenSidebar.update();
         for (const refresh of this._loadOnSaveToggleRefreshers) {
           refresh();
         }
@@ -1461,6 +1474,13 @@ class PluginPlayground {
     requirejs.require.config({
       baseUrl: baseURL
     });
+
+    const composite = settings.composite as Record<string, unknown>;
+    const rawCommandInsertMode = this._stringValue(
+      composite[COMMAND_INSERT_DEFAULT_MODE_SETTING]
+    );
+    this._commandInsertMode =
+      rawCommandInsertMode === 'ai' ? 'ai' : DEFAULT_COMMAND_INSERT_MODE;
   }
 
   private _getTokenRecords(): ReadonlyArray<TokenSidebar.ITokenRecord> {
@@ -2087,25 +2107,14 @@ class PluginPlayground {
       return;
     }
 
-    const editorWidget = this.editorTracker.currentWidget;
-    if (!editorWidget) {
-      await showDialog({
-        title: 'No active editor',
-        body: 'Open a text editor tab to insert an import statement.',
-        buttons: [Dialog.okButton()]
-      });
+    const activeEditor = await this._requireEditableEditor(
+      'Open a text editor tab to insert an import statement.'
+    );
+    if (!activeEditor) {
       return;
     }
 
-    const sourceModel = editorWidget.content.model;
-    if (!sourceModel || !sourceModel.sharedModel) {
-      await showDialog({
-        title: 'No editable content',
-        body: 'The active tab does not expose editable source text.',
-        buttons: [Dialog.okButton()]
-      });
-      return;
-    }
+    const { editorWidget, sourceModel } = activeEditor;
 
     const source = sourceModel.sharedModel.getSource();
     const importResult = insertImportStatement(source, tokenReference);
@@ -2133,14 +2142,278 @@ class PluginPlayground {
     if (!parseTokenReference(tokenName)) {
       return false;
     }
+    return this._hasEditableEditor();
+  }
 
+  private async _insertCommandExecution(
+    commandId: string,
+    mode: CommandInsertMode
+  ): Promise<void> {
+    if (this._commandInsertMode !== mode) {
+      this._commandInsertMode = mode;
+      this._tokenSidebar?.update();
+      try {
+        await this.settings.set(COMMAND_INSERT_DEFAULT_MODE_SETTING, mode);
+      } catch (error) {
+        console.warn(
+          `Failed to persist "${COMMAND_INSERT_DEFAULT_MODE_SETTING}" setting.`,
+          error
+        );
+      }
+    }
+
+    const activeEditor = await this._requireEditableEditor(
+      'Open a text editor tab to insert command execution.'
+    );
+    if (!activeEditor) {
+      return;
+    }
+
+    if (mode === 'insert') {
+      this._insertCommandExecutionAtCursor(activeEditor, commandId);
+      return;
+    }
+
+    const source = activeEditor.sourceModel.sharedModel.getSource();
+    const appVariableName = findPluginActivateAppParameterName(source);
+    const suggestedSnippet = this._commandExecutionSnippet(
+      commandId,
+      appVariableName ?? 'app'
+    );
+
+    try {
+      await this._promptAIToInsertCommand({
+        activeEditor,
+        commandId,
+        suggestedSnippet,
+        appVariableName
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(
+        'Failed to prefill JupyterLite AI prompt for insertion.',
+        error
+      );
+      Notification.warning(
+        `Could not prefill AI insertion prompt for "${commandId}": ${message}`,
+        {
+          autoClose: 5000
+        }
+      );
+    }
+  }
+
+  private _insertCommandExecutionAtCursor(
+    activeEditor: {
+      editorWidget: IDocumentWidget<FileEditor>;
+      sourceModel: NonNullable<FileEditor['model']>;
+    },
+    commandId: string
+  ): void {
+    const { editorWidget, sourceModel } = activeEditor;
+    const editor = editorWidget.content.editor;
+    const originalSource = sourceModel.sharedModel.getSource();
+    const activateAppContext = ensurePluginActivateAppContext(originalSource);
+    if (activateAppContext.source !== originalSource) {
+      sourceModel.sharedModel.updateSource(
+        0,
+        originalSource.length,
+        activateAppContext.source
+      );
+    }
+
+    const cursorPosition = editor.getCursorPosition();
+    const insertionOffset = editor.getOffsetAt(cursorPosition);
+    const insertText = this._commandExecutionSnippet(
+      commandId,
+      activateAppContext.appVariableName
+    );
+
+    editor.setSelection({
+      start: cursorPosition,
+      end: cursorPosition
+    });
+    if (editor.replaceSelection) {
+      editor.replaceSelection(insertText);
+    } else {
+      sourceModel.sharedModel.updateSource(
+        insertionOffset,
+        insertionOffset,
+        insertText
+      );
+      const fallbackCursorPosition = editor.getPositionAt(
+        insertionOffset + insertText.length
+      );
+      if (fallbackCursorPosition) {
+        editor.setCursorPosition(fallbackCursorPosition);
+      }
+    }
+
+    const nextCursorPosition = editor.getCursorPosition();
+    editor.revealPosition(nextCursorPosition);
+    window.requestAnimationFrame(() => {
+      ContentUtils.highlightEditorLines(editor, [nextCursorPosition.line]);
+    });
+    editor.focus();
+  }
+
+  private async _promptAIToInsertCommand(options: {
+    commandId: string;
+    activeEditor: {
+      editorWidget: IDocumentWidget<FileEditor>;
+      sourceModel: NonNullable<FileEditor['model']>;
+    };
+    suggestedSnippet: string;
+    appVariableName: string | null;
+  }): Promise<void> {
+    const { editorWidget, sourceModel } = options.activeEditor;
+    const source = sourceModel.sharedModel.getSource();
+    const prompt = this._buildCommandInsertAIPrompt({
+      source,
+      commandId: options.commandId,
+      path: editorWidget.context.path,
+      suggestedSnippet: options.suggestedSnippet,
+      appVariableName: options.appVariableName
+    });
+
+    if (!this.app.commands.hasCommand(JUPYTERLITE_AI_OPEN_CHAT_COMMAND)) {
+      throw new Error(
+        `${JUPYTERLITE_AI_INSTALL_HINT} Missing command: "${JUPYTERLITE_AI_OPEN_CHAT_COMMAND}".`
+      );
+    }
+
+    await this.app.commands.execute(JUPYTERLITE_AI_OPEN_CHAT_COMMAND, {
+      area: 'side'
+    });
+
+    const inputModel = this._requireJupyterLiteAIChatInputModel();
+    this._setJupyterLiteAIInputPrompt(inputModel, prompt);
+  }
+
+  private _requireJupyterLiteAIChatInputModel(): {
+    value: string;
+    focus: () => void;
+  } {
+    const sideWidgets = Array.from(this.app.shell.widgets('left'));
+    const chatPanel = sideWidgets.find(
+      widget => widget.id === JUPYTERLITE_AI_CHAT_PANEL_ID
+    ) as
+      | {
+          current?: {
+            model?: { input?: unknown };
+          };
+        }
+      | undefined;
+
+    const candidate = chatPanel?.current?.model?.input;
+    if (
+      candidate &&
+      typeof candidate === 'object' &&
+      'value' in candidate &&
+      typeof candidate.value === 'string' &&
+      'focus' in candidate &&
+      typeof candidate.focus === 'function'
+    ) {
+      return candidate as { value: string; focus: () => void };
+    }
+    throw new Error(
+      'Opened JupyterLite AI chat, but could not access chat input model.'
+    );
+  }
+
+  private _setJupyterLiteAIInputPrompt(
+    inputModel: { value: string; focus: () => void },
+    prompt: string
+  ): void {
+    inputModel.value = prompt;
+    inputModel.focus();
+  }
+
+  private _buildCommandInsertAIPrompt(options: {
+    source: string;
+    commandId: string;
+    path: string;
+    suggestedSnippet: string;
+    appVariableName: string | null;
+  }): string {
+    const lines = options.source.split(/\r?\n/);
+    const context = lines
+      .map((line, index) => `${index + 1}: ${line}`)
+      .join('\n');
+    const normalizedPath = ContentUtils.normalizeContentsPath(options.path);
+    const appContextInstruction = options.appVariableName
+      ? `Use the activate() app variable: ${options.appVariableName}.`
+      : 'If app is missing, add JupyterFrontEnd import and declare activate(app: JupyterFrontEnd, ...).';
+    return [
+      'Insert this command execution in the best location in this file.',
+      'Keep exactly one final execute() call for this command.',
+      appContextInstruction,
+      `Command ID: ${options.commandId}`,
+      `Suggested command call: ${options.suggestedSnippet}`,
+      `File: ${normalizedPath || '(unsaved)'}`,
+      'Context:',
+      context
+    ].join('\n');
+  }
+
+  private _commandExecutionSnippet(
+    commandId: string,
+    appVariableName: string
+  ): string {
+    const escapedCommandId = commandId
+      .replace(/\\/g, '\\\\')
+      .replace(/'/g, "\\'");
+    return `${appVariableName}.commands.execute('${escapedCommandId}');`;
+  }
+
+  private _getEditableEditor(): {
+    editorWidget: IDocumentWidget<FileEditor>;
+    sourceModel: NonNullable<FileEditor['model']>;
+  } | null {
     const editorWidget = this.editorTracker.currentWidget;
-    if (!editorWidget) {
-      return false;
+    if (!editorWidget || editorWidget !== this.app.shell.currentWidget) {
+      return null;
     }
 
     const sourceModel = editorWidget.content.model;
-    return !!(sourceModel && sourceModel.sharedModel);
+    if (!sourceModel || !sourceModel.sharedModel) {
+      return null;
+    }
+
+    return {
+      editorWidget,
+      sourceModel
+    };
+  }
+
+  private _hasEditableEditor(): boolean {
+    return this._getEditableEditor() !== null;
+  }
+
+  private async _requireEditableEditor(noEditorMessage: string): Promise<{
+    editorWidget: IDocumentWidget<FileEditor>;
+    sourceModel: NonNullable<FileEditor['model']>;
+  } | null> {
+    const activeEditor = this._getEditableEditor();
+    if (activeEditor) {
+      return activeEditor;
+    }
+
+    if (!this.editorTracker.currentWidget) {
+      await showDialog({
+        title: 'No active editor',
+        body: noEditorMessage,
+        buttons: [Dialog.okButton()]
+      });
+      return null;
+    }
+
+    await showDialog({
+      title: 'No editable content',
+      body: 'The active tab does not expose editable source text.',
+      buttons: [Dialog.okButton()]
+    });
+    return null;
   }
 
   /**
@@ -2372,6 +2645,7 @@ class PluginPlayground {
     string,
     MainAreaWidget<IFrame>
   >();
+  private _commandInsertMode: CommandInsertMode = DEFAULT_COMMAND_INSERT_MODE;
   private _copiedCommandId: string | null = null;
   private _copiedCommandTimer: number | null = null;
   private _playgroundSidebar: SidePanel | null = null;

--- a/src/token-insertion.ts
+++ b/src/token-insertion.ts
@@ -38,7 +38,6 @@ export function insertImportStatement(
   source: string,
   tokenReference: ITokenReference
 ): ISourceUpdateResult {
-  const statement = `import { ${tokenReference.tokenSymbol} } from '${tokenReference.packageName}';`;
   const existingImportLines = hasNamedValueImport(
     source,
     tokenReference.packageName,
@@ -48,6 +47,15 @@ export function insertImportStatement(
     return { source, changedLines: existingImportLines };
   }
 
+  const groupedImportResult = insertIntoExistingPackageImport(
+    source,
+    tokenReference
+  );
+  if (groupedImportResult) {
+    return groupedImportResult;
+  }
+
+  const statement = `import { ${tokenReference.tokenSymbol} } from '${tokenReference.packageName}';`;
   const separator = source.length > 0 ? '\n' : '';
   return {
     source: `${statement}${separator}${source}`,
@@ -680,6 +688,110 @@ function jupyterFrontEndParameterName(
     }
   }
   return null;
+}
+
+function insertIntoExistingPackageImport(
+  source: string,
+  tokenReference: ITokenReference
+): ISourceUpdateResult | null {
+  const sourceFile = ts.createSourceFile(
+    'plugin-playground-import-grouping.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  );
+  const statement = `import { ${tokenReference.tokenSymbol} } from '${tokenReference.packageName}';`;
+  const lineEnding = source.includes('\r\n') ? '\r\n' : '\n';
+  let lastMatchingImport: ts.ImportDeclaration | null = null;
+
+  for (const candidate of sourceFile.statements) {
+    if (!ts.isImportDeclaration(candidate)) {
+      continue;
+    }
+    if (
+      !ts.isStringLiteral(candidate.moduleSpecifier) ||
+      candidate.moduleSpecifier.text !== tokenReference.packageName
+    ) {
+      continue;
+    }
+
+    lastMatchingImport = candidate;
+    const importClause = candidate.importClause;
+    if (!importClause || importClause.isTypeOnly) {
+      continue;
+    }
+
+    const namedBindings = importClause.namedBindings;
+    if (!namedBindings) {
+      if (importClause.name) {
+        return applyEditsWithChangedLines(source, [
+          {
+            start: importClause.name.end,
+            end: importClause.name.end,
+            text: `, { ${tokenReference.tokenSymbol} }`
+          }
+        ]);
+      }
+      continue;
+    }
+
+    if (ts.isNamespaceImport(namedBindings)) {
+      continue;
+    }
+
+    if (namedBindings.elements.length === 0) {
+      return applyEditsWithChangedLines(source, [
+        {
+          start: namedBindings.elements.pos,
+          end: namedBindings.elements.pos,
+          text: tokenReference.tokenSymbol
+        }
+      ]);
+    }
+
+    const insertionPosition = namedBindings.elements.end;
+    const hasTrailingComma = Boolean(namedBindings.elements.hasTrailingComma);
+    const namedBindingsText = source.slice(
+      namedBindings.getStart(sourceFile),
+      namedBindings.end
+    );
+    if (namedBindingsText.includes('\n')) {
+      const firstElement = namedBindings.elements[0];
+      const elementIndent = firstElement
+        ? lineIndent(source, firstElement.getStart(sourceFile))
+        : '  ';
+      return applyEditsWithChangedLines(source, [
+        {
+          start: insertionPosition,
+          end: insertionPosition,
+          text: `${hasTrailingComma ? '' : ','}${lineEnding}${elementIndent}${
+            tokenReference.tokenSymbol
+          }`
+        }
+      ]);
+    }
+
+    return applyEditsWithChangedLines(source, [
+      {
+        start: insertionPosition,
+        end: insertionPosition,
+        text: `${hasTrailingComma ? ' ' : ', '}${tokenReference.tokenSymbol}`
+      }
+    ]);
+  }
+
+  if (!lastMatchingImport) {
+    return null;
+  }
+
+  return applyEditsWithChangedLines(source, [
+    {
+      start: lastMatchingImport.end,
+      end: lastMatchingImport.end,
+      text: `${lineEnding}${statement}`
+    }
+  ]);
 }
 
 function hasNamedValueImport(

--- a/src/token-insertion.ts
+++ b/src/token-insertion.ts
@@ -10,6 +10,11 @@ interface ISourceUpdateResult {
   changedLines: number[];
 }
 
+export interface IActivateAppContextResult {
+  source: string;
+  appVariableName: string;
+}
+
 const DEPENDENCY_MULTILINE_THRESHOLD = 3;
 const PARAMETER_MULTILINE_THRESHOLD = 3;
 
@@ -71,7 +76,7 @@ export function insertTokenDependency(
   if (!activateProperty) {
     return { source, changedLines: [] };
   }
-  const activate = resolveActivateFunction(activateProperty);
+  const activate = resolveActivateFunction(activateProperty, sourceFile);
 
   const requiresProperty = findObjectProperty(pluginObject, 'requires');
   const optionalProperty = findObjectProperty(pluginObject, 'optional');
@@ -267,6 +272,138 @@ export function insertTokenDependency(
   return applyEditsWithChangedLines(source, edits);
 }
 
+export function ensurePluginActivateAppContext(
+  source: string
+): IActivateAppContextResult {
+  const existingAppParameterName = findPluginActivateAppParameterName(source);
+  if (existingAppParameterName) {
+    return { source, appVariableName: existingAppParameterName };
+  }
+
+  const sourceFile = ts.createSourceFile(
+    'plugin-playground-activate-context.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  );
+  const pluginObject = resolveDefaultPluginObject(sourceFile);
+  if (!pluginObject) {
+    return { source, appVariableName: 'app' };
+  }
+  const activateProperty = findObjectProperty(pluginObject, 'activate');
+  if (!activateProperty) {
+    return { source, appVariableName: 'app' };
+  }
+  const activate = resolveActivateFunction(activateProperty, sourceFile);
+  if (!activate) {
+    return { source, appVariableName: 'app' };
+  }
+
+  const importResult = insertImportStatement(source, {
+    packageName: '@jupyterlab/application',
+    tokenSymbol: 'JupyterFrontEnd'
+  });
+  let updatedSource = importResult.source;
+  const updatedSourceFile = ts.createSourceFile(
+    'plugin-playground-activate-context-updated.ts',
+    updatedSource,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  );
+  const updatedPluginObject = resolveDefaultPluginObject(updatedSourceFile);
+  if (!updatedPluginObject) {
+    return { source: updatedSource, appVariableName: 'app' };
+  }
+  const updatedActivateProperty = findObjectProperty(
+    updatedPluginObject,
+    'activate'
+  );
+  if (!updatedActivateProperty) {
+    return { source: updatedSource, appVariableName: 'app' };
+  }
+  const updatedActivate = resolveActivateFunction(
+    updatedActivateProperty,
+    updatedSourceFile
+  );
+  if (!updatedActivate) {
+    return { source: updatedSource, appVariableName: 'app' };
+  }
+
+  const firstParameter = updatedActivate.parameters[0];
+  if (
+    firstParameter &&
+    ts.isIdentifier(firstParameter.name) &&
+    !firstParameter.type
+  ) {
+    const appVariableName = firstParameter.name.text || 'app';
+    const parameterResult = applyEditsWithChangedLines(updatedSource, [
+      {
+        start: firstParameter.getStart(updatedSourceFile),
+        end: firstParameter.end,
+        text: `${appVariableName}: JupyterFrontEnd`
+      }
+    ]);
+    return { source: parameterResult.source, appVariableName };
+  }
+
+  const existingParameterNames = new Set<string>();
+  for (const parameter of updatedActivate.parameters) {
+    if (ts.isIdentifier(parameter.name)) {
+      existingParameterNames.add(parameter.name.text);
+    }
+  }
+  let appVariableName = 'app';
+  let suffix = 2;
+  while (existingParameterNames.has(appVariableName)) {
+    appVariableName = `app${suffix}`;
+    suffix += 1;
+  }
+
+  const insertAt =
+    updatedActivate.parameters.length > 0
+      ? updatedActivate.parameters[0].getStart(updatedSourceFile)
+      : updatedActivate.parameters.pos;
+  const prefix = updatedActivate.parameters.length > 0 ? ', ' : '';
+  const parameterResult = applyEditsWithChangedLines(updatedSource, [
+    {
+      start: insertAt,
+      end: insertAt,
+      text: `${appVariableName}: JupyterFrontEnd${prefix}`
+    }
+  ]);
+  updatedSource = parameterResult.source;
+  return { source: updatedSource, appVariableName };
+}
+
+export function findPluginActivateAppParameterName(
+  source: string
+): string | null {
+  const sourceFile = ts.createSourceFile(
+    'plugin-playground-command-insertion.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  );
+  const pluginObjects = resolveDefaultPluginObjects(sourceFile);
+  for (const pluginObject of pluginObjects) {
+    const activateProperty = findObjectProperty(pluginObject, 'activate');
+    if (!activateProperty) {
+      continue;
+    }
+    const activate = resolveActivateFunction(activateProperty, sourceFile);
+    const appParameterName = activate
+      ? jupyterFrontEndParameterName(activate, sourceFile)
+      : null;
+    if (appParameterName) {
+      return appParameterName;
+    }
+  }
+  return null;
+}
+
 function applyEditsWithChangedLines(
   source: string,
   edits: Array<{ start: number; end: number; text: string }>
@@ -375,23 +512,80 @@ function unwrapExpression(expression: ts.Expression): ts.Expression {
 function resolveDefaultPluginObject(
   sourceFile: ts.SourceFile
 ): ts.ObjectLiteralExpression | null {
-  let exported: ts.Expression | null = null;
+  const pluginObjects = resolveDefaultPluginObjects(sourceFile);
+  return pluginObjects.length > 0 ? pluginObjects[0] : null;
+}
+
+function resolveDefaultPluginObjects(
+  sourceFile: ts.SourceFile
+): ts.ObjectLiteralExpression[] {
+  const exported = resolveDefaultExportExpression(sourceFile);
+  if (!exported) {
+    return [];
+  }
+  return resolvePluginObjectsFromExpression(
+    sourceFile,
+    exported,
+    new Set<string>()
+  );
+}
+
+function resolveDefaultExportExpression(
+  sourceFile: ts.SourceFile
+): ts.Expression | null {
   for (const statement of sourceFile.statements) {
     if (ts.isExportAssignment(statement) && !statement.isExportEquals) {
-      exported = unwrapExpression(statement.expression);
-      break;
+      return unwrapExpression(statement.expression);
     }
   }
-  if (!exported) {
-    return null;
-  }
-  if (ts.isObjectLiteralExpression(exported)) {
-    return exported;
-  }
-  if (!ts.isIdentifier(exported)) {
-    return null;
-  }
+  return null;
+}
 
+function resolvePluginObjectsFromExpression(
+  sourceFile: ts.SourceFile,
+  expression: ts.Expression,
+  seenIdentifiers: Set<string>
+): ts.ObjectLiteralExpression[] {
+  const unwrapped = unwrapExpression(expression);
+  if (ts.isObjectLiteralExpression(unwrapped)) {
+    return [unwrapped];
+  }
+  if (ts.isArrayLiteralExpression(unwrapped)) {
+    const pluginObjects: ts.ObjectLiteralExpression[] = [];
+    for (const element of unwrapped.elements) {
+      if (ts.isSpreadElement(element)) {
+        continue;
+      }
+      const nestedObjects = resolvePluginObjectsFromExpression(
+        sourceFile,
+        element,
+        seenIdentifiers
+      );
+      for (const pluginObject of nestedObjects) {
+        pluginObjects.push(pluginObject);
+      }
+    }
+    return pluginObjects;
+  }
+  if (ts.isIdentifier(unwrapped)) {
+    return resolvePluginObjectsFromIdentifier(
+      sourceFile,
+      unwrapped.text,
+      seenIdentifiers
+    );
+  }
+  return [];
+}
+
+function resolvePluginObjectsFromIdentifier(
+  sourceFile: ts.SourceFile,
+  identifierName: string,
+  seenIdentifiers: Set<string>
+): ts.ObjectLiteralExpression[] {
+  if (seenIdentifiers.has(identifierName)) {
+    return [];
+  }
+  seenIdentifiers.add(identifierName);
   for (const statement of sourceFile.statements) {
     if (!ts.isVariableStatement(statement)) {
       continue;
@@ -399,19 +593,23 @@ function resolveDefaultPluginObject(
     for (const declaration of statement.declarationList.declarations) {
       if (
         ts.isIdentifier(declaration.name) &&
-        declaration.name.text === exported.text &&
-        declaration.initializer &&
-        ts.isObjectLiteralExpression(declaration.initializer)
+        declaration.name.text === identifierName &&
+        declaration.initializer
       ) {
-        return declaration.initializer;
+        return resolvePluginObjectsFromExpression(
+          sourceFile,
+          declaration.initializer,
+          seenIdentifiers
+        );
       }
     }
   }
-  return null;
+  return [];
 }
 
 function resolveActivateFunction(
-  activateProperty: ts.ObjectLiteralElementLike
+  activateProperty: ts.ObjectLiteralElementLike,
+  sourceFile?: ts.SourceFile
 ): ts.FunctionLikeDeclarationBase | null {
   if (ts.isMethodDeclaration(activateProperty)) {
     return activateProperty;
@@ -422,6 +620,64 @@ function resolveActivateFunction(
       ts.isFunctionExpression(activateProperty.initializer))
   ) {
     return activateProperty.initializer;
+  }
+  if (
+    sourceFile &&
+    ts.isPropertyAssignment(activateProperty) &&
+    ts.isIdentifier(activateProperty.initializer)
+  ) {
+    const referencedFunction = resolveFunctionLikeByName(
+      sourceFile,
+      activateProperty.initializer.text
+    );
+    if (referencedFunction) {
+      return referencedFunction;
+    }
+  }
+  return null;
+}
+
+function resolveFunctionLikeByName(
+  sourceFile: ts.SourceFile,
+  functionName: string
+): ts.FunctionLikeDeclarationBase | null {
+  for (const statement of sourceFile.statements) {
+    if (
+      ts.isFunctionDeclaration(statement) &&
+      statement.name?.text === functionName
+    ) {
+      return statement;
+    }
+    if (!ts.isVariableStatement(statement)) {
+      continue;
+    }
+    for (const declaration of statement.declarationList.declarations) {
+      if (
+        ts.isIdentifier(declaration.name) &&
+        declaration.name.text === functionName &&
+        declaration.initializer &&
+        (ts.isArrowFunction(declaration.initializer) ||
+          ts.isFunctionExpression(declaration.initializer))
+      ) {
+        return declaration.initializer;
+      }
+    }
+  }
+  return null;
+}
+
+function jupyterFrontEndParameterName(
+  activate: ts.FunctionLikeDeclarationBase,
+  sourceFile: ts.SourceFile
+): string | null {
+  for (const parameter of activate.parameters) {
+    if (!ts.isIdentifier(parameter.name) || !parameter.type) {
+      continue;
+    }
+    const typeText = parameter.type.getText(sourceFile);
+    if (/\bJupyterFrontEnd\b/.test(typeText)) {
+      return parameter.name.text;
+    }
   }
   return null;
 }

--- a/src/token-insertion.ts
+++ b/src/token-insertion.ts
@@ -678,6 +678,13 @@ function jupyterFrontEndParameterName(
   activate: ts.FunctionLikeDeclarationBase,
   sourceFile: ts.SourceFile
 ): string | null {
+  const firstParameter = activate.parameters[0];
+  const firstUntypedIdentifierName =
+    firstParameter &&
+    ts.isIdentifier(firstParameter.name) &&
+    !firstParameter.type
+      ? firstParameter.name.text
+      : null;
   for (const parameter of activate.parameters) {
     if (!ts.isIdentifier(parameter.name) || !parameter.type) {
       continue;
@@ -687,7 +694,7 @@ function jupyterFrontEndParameterName(
       return parameter.name.text;
     }
   }
-  return null;
+  return firstUntypedIdentifierName;
 }
 
 function insertIntoExistingPackageImport(

--- a/src/token-sidebar.tsx
+++ b/src/token-sidebar.tsx
@@ -448,20 +448,14 @@ export class TokenSidebar extends ReactWidget {
                               elementSize: 'normal',
                               className: 'jp-PluginPlayground-actionIcon'
                             })}
-                            {isAICommandInsertMode ? (
-                              <span
-                                className="jp-PluginPlayground-commandInsertAIBadge"
-                                aria-hidden="true"
-                              >
-                                {React.createElement(offlineBoltIcon.react, {
+                            {isAICommandInsertMode
+                              ? React.createElement(offlineBoltIcon.react, {
                                   tag: 'span',
                                   elementSize: 'small',
                                   className:
-                                    'jp-PluginPlayground-commandInsertAIBadgeIcon'
-                                })}
-                                AI
-                              </span>
-                            ) : null}
+                                    'jp-PluginPlayground-commandInsertAIMarkerIcon'
+                                })
+                              : null}
                           </button>
                           <button
                             className="jp-Button jp-mod-styled jp-mod-minimal jp-PluginPlayground-actionButton jp-PluginPlayground-commandInsertMenuButton"

--- a/src/token-sidebar.tsx
+++ b/src/token-sidebar.tsx
@@ -444,7 +444,7 @@ export class TokenSidebar extends ReactWidget {
                               : null}
                           </button>
                           <button
-                            className="jp-Button jp-mod-styled jp-mod-minimal jp-PluginPlayground-actionButton jp-PluginPlayground-commandInsertMenuButton"
+                            className="jp-Button jp-mod-styled jp-mod-minimal jp-PluginPlayground-actionButton jp-PluginPlayground-commandInsertMenuButton jp-PluginPlayground-commandInsertDropdownButton"
                             type="button"
                             onMouseDown={event => {
                               event.preventDefault();

--- a/src/token-sidebar.tsx
+++ b/src/token-sidebar.tsx
@@ -51,6 +51,7 @@ export namespace TokenSidebar {
     ) => void;
     onInsertImport: (tokenName: string) => Promise<void> | void;
     isImportEnabled: (tokenName: string) => boolean;
+    onSetCommandInsertMode: (mode: CommandInsertMode) => Promise<void> | void;
     onInsertCommand: (
       commandId: string,
       mode: CommandInsertMode
@@ -74,17 +75,6 @@ const EXTENSION_POINT_PANEL_ID = 'jp-PluginPlayground-extensionPointPanel';
 const COMMAND_INSERT_MENU_INSERT_ID =
   'plugin-playground:command-insert-selection';
 const COMMAND_INSERT_MENU_AI_ID = 'plugin-playground:command-insert-ai';
-const COMMAND_INSERT_MENU_ARGS_SCHEMA = {
-  type: 'object',
-  additionalProperties: false,
-  required: ['commandId'],
-  properties: {
-    commandId: {
-      type: 'string',
-      description: 'Command ID used for insertion.'
-    }
-  }
-};
 
 export function filterTokenRecords(
   tokens: ReadonlyArray<TokenSidebar.ITokenRecord>,
@@ -135,6 +125,9 @@ export class TokenSidebar extends ReactWidget {
   ) => void;
   private readonly _onInsertImport: (tokenName: string) => Promise<void> | void;
   private readonly _isImportEnabled: (tokenName: string) => boolean;
+  private readonly _onSetCommandInsertMode: (
+    mode: CommandInsertMode
+  ) => Promise<void> | void;
   private readonly _onInsertCommand: (
     commandId: string,
     mode: CommandInsertMode
@@ -171,32 +164,25 @@ export class TokenSidebar extends ReactWidget {
     this._openDocumentationLink = options.openDocumentationLink;
     this._onInsertImport = options.onInsertImport;
     this._isImportEnabled = options.isImportEnabled;
+    this._onSetCommandInsertMode = options.onSetCommandInsertMode;
     this._onInsertCommand = options.onInsertCommand;
     this._getCommandInsertMode = options.getCommandInsertMode;
     this._isCommandInsertEnabled = options.isCommandInsertEnabled;
     this.addClass('jp-PluginPlayground-sidebar');
     this._commandInsertMenuCommands.addCommand(COMMAND_INSERT_MENU_INSERT_ID, {
       label: 'Insert in selection',
-      describedBy: { args: COMMAND_INSERT_MENU_ARGS_SCHEMA },
+      describedBy: { args: null },
       isToggled: () => this._getCommandInsertMode() === 'insert',
-      execute: args => {
-        const commandId = this._commandIdFromMenuArgs(args);
-        if (!commandId) {
-          return;
-        }
-        void this._insertCommand(commandId, 'insert');
+      execute: () => {
+        void this._setCommandInsertMode('insert');
       }
     });
     this._commandInsertMenuCommands.addCommand(COMMAND_INSERT_MENU_AI_ID, {
       label: 'Prompt AI to insert',
-      describedBy: { args: COMMAND_INSERT_MENU_ARGS_SCHEMA },
+      describedBy: { args: null },
       isToggled: () => this._getCommandInsertMode() === 'ai',
-      execute: args => {
-        const commandId = this._commandIdFromMenuArgs(args);
-        if (!commandId) {
-          return;
-        }
-        void this._insertCommand(commandId, 'ai');
+      execute: () => {
+        void this._setCommandInsertMode('ai');
       }
     });
   }
@@ -464,10 +450,7 @@ export class TokenSidebar extends ReactWidget {
                               event.preventDefault();
                             }}
                             onClick={event => {
-                              this._openCommandInsertMenu(
-                                event.currentTarget,
-                                command.id
-                              );
+                              this._openCommandInsertMenu(event.currentTarget);
                             }}
                             disabled={!canInsertCommand}
                             aria-haspopup="menu"
@@ -899,18 +882,13 @@ export class TokenSidebar extends ReactWidget {
     }
   }
 
-  private _openCommandInsertMenu(
-    anchorButton: HTMLButtonElement,
-    commandId: string
-  ): void {
+  private _openCommandInsertMenu(anchorButton: HTMLButtonElement): void {
     this._commandInsertMenu.clearItems();
     this._commandInsertMenu.addItem({
-      command: COMMAND_INSERT_MENU_INSERT_ID,
-      args: { commandId }
+      command: COMMAND_INSERT_MENU_INSERT_ID
     });
     this._commandInsertMenu.addItem({
-      command: COMMAND_INSERT_MENU_AI_ID,
-      args: { commandId }
+      command: COMMAND_INSERT_MENU_AI_ID
     });
     const anchorRect = anchorButton.getBoundingClientRect();
     const splitRect = anchorButton.parentElement?.getBoundingClientRect();
@@ -920,12 +898,18 @@ export class TokenSidebar extends ReactWidget {
     );
   }
 
-  private _commandIdFromMenuArgs(args: unknown): string {
-    return args && typeof args === 'object' && 'commandId' in args
-      ? typeof args.commandId === 'string'
-        ? args.commandId
-        : ''
-      : '';
+  private async _setCommandInsertMode(mode: CommandInsertMode): Promise<void> {
+    try {
+      await this._onSetCommandInsertMode(mode);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Unknown mode switch error';
+      await showDialog({
+        title: 'Failed to change command insertion mode',
+        body: `Could not switch to "${mode}" mode. ${message}`,
+        buttons: [Dialog.okButton()]
+      });
+    }
   }
 
   private async _insertCommand(

--- a/src/token-sidebar.tsx
+++ b/src/token-sidebar.tsx
@@ -2,13 +2,17 @@ import { Dialog, ReactWidget, showDialog } from '@jupyterlab/apputils';
 
 import {
   addIcon,
+  caretDownEmptyIcon,
   checkIcon,
   copyIcon,
   jsonIcon,
+  MenuSvg,
+  offlineBoltIcon,
   type LabIcon
 } from '@jupyterlab/ui-components';
 
 import * as React from 'react';
+import { CommandRegistry } from '@lumino/commands';
 import type { IKnownModule } from './known-modules';
 import {
   type ICommandArgumentDocumentation,
@@ -22,6 +26,8 @@ import {
   githubRepositoryIcon,
   npmPackageIcon
 } from './icons';
+
+export type CommandInsertMode = 'insert' | 'ai';
 
 export namespace TokenSidebar {
   export interface ITokenRecord {
@@ -45,6 +51,12 @@ export namespace TokenSidebar {
     ) => void;
     onInsertImport: (tokenName: string) => Promise<void> | void;
     isImportEnabled: (tokenName: string) => boolean;
+    onInsertCommand: (
+      commandId: string,
+      mode: CommandInsertMode
+    ) => Promise<void> | void;
+    getCommandInsertMode: () => CommandInsertMode;
+    isCommandInsertEnabled: () => boolean;
   }
 }
 
@@ -59,6 +71,20 @@ interface IKnownModuleLink {
   url: string;
 }
 const EXTENSION_POINT_PANEL_ID = 'jp-PluginPlayground-extensionPointPanel';
+const COMMAND_INSERT_MENU_INSERT_ID =
+  'plugin-playground:command-insert-selection';
+const COMMAND_INSERT_MENU_AI_ID = 'plugin-playground:command-insert-ai';
+const COMMAND_INSERT_MENU_ARGS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['commandId'],
+  properties: {
+    commandId: {
+      type: 'string',
+      description: 'Command ID used for insertion.'
+    }
+  }
+};
 
 export function filterTokenRecords(
   tokens: ReadonlyArray<TokenSidebar.ITokenRecord>,
@@ -109,6 +135,12 @@ export class TokenSidebar extends ReactWidget {
   ) => void;
   private readonly _onInsertImport: (tokenName: string) => Promise<void> | void;
   private readonly _isImportEnabled: (tokenName: string) => boolean;
+  private readonly _onInsertCommand: (
+    commandId: string,
+    mode: CommandInsertMode
+  ) => Promise<void> | void;
+  private readonly _getCommandInsertMode: () => CommandInsertMode;
+  private readonly _isCommandInsertEnabled: () => boolean;
   private _query = '';
   private _activeView: ExtensionPointView = 'tokens';
   private _isDiscoveringKnownModules = false;
@@ -123,6 +155,10 @@ export class TokenSidebar extends ReactWidget {
     ICommandArgumentDocumentation | null
   >();
   private _commandArgumentCounts = new Map<string, number | null>();
+  private readonly _commandInsertMenuCommands = new CommandRegistry();
+  private readonly _commandInsertMenu = new MenuSvg({
+    commands: this._commandInsertMenuCommands
+  });
 
   constructor(options: TokenSidebar.IOptions) {
     super();
@@ -135,7 +171,34 @@ export class TokenSidebar extends ReactWidget {
     this._openDocumentationLink = options.openDocumentationLink;
     this._onInsertImport = options.onInsertImport;
     this._isImportEnabled = options.isImportEnabled;
+    this._onInsertCommand = options.onInsertCommand;
+    this._getCommandInsertMode = options.getCommandInsertMode;
+    this._isCommandInsertEnabled = options.isCommandInsertEnabled;
     this.addClass('jp-PluginPlayground-sidebar');
+    this._commandInsertMenuCommands.addCommand(COMMAND_INSERT_MENU_INSERT_ID, {
+      label: 'Insert in selection',
+      describedBy: { args: COMMAND_INSERT_MENU_ARGS_SCHEMA },
+      isToggled: () => this._getCommandInsertMode() === 'insert',
+      execute: args => {
+        const commandId = this._commandIdFromMenuArgs(args);
+        if (!commandId) {
+          return;
+        }
+        void this._insertCommand(commandId, 'insert');
+      }
+    });
+    this._commandInsertMenuCommands.addCommand(COMMAND_INSERT_MENU_AI_ID, {
+      label: 'Prompt AI to insert',
+      describedBy: { args: COMMAND_INSERT_MENU_ARGS_SCHEMA },
+      isToggled: () => this._getCommandInsertMode() === 'ai',
+      execute: args => {
+        const commandId = this._commandIdFromMenuArgs(args);
+        if (!commandId) {
+          return;
+        }
+        void this._insertCommand(commandId, 'ai');
+      }
+    });
   }
 
   public showPackagesView(): void {
@@ -147,6 +210,7 @@ export class TokenSidebar extends ReactWidget {
       window.clearTimeout(this._copiedTimer);
       this._copiedTimer = null;
     }
+    this._commandInsertMenu.dispose();
     super.dispose();
   }
 
@@ -154,6 +218,9 @@ export class TokenSidebar extends ReactWidget {
     const isTokenView = this._activeView === 'tokens';
     const isCommandView = this._activeView === 'commands';
     const isPackagesView = this._activeView === 'packages';
+    const commandInsertMode = this._getCommandInsertMode();
+    const isAICommandInsertMode = commandInsertMode === 'ai';
+    const canInsertCommand = this._isCommandInsertEnabled();
     const activeTabId = `jp-PluginPlayground-extensionPointTab-${this._activeView}`;
     let tokens: ReadonlyArray<TokenSidebar.ITokenRecord> = [];
     let commands: ReadonlyArray<ICommandRecord> = [];
@@ -351,6 +418,75 @@ export class TokenSidebar extends ReactWidget {
                         {command.id}
                       </code>
                       <div className="jp-PluginPlayground-tokenActions">
+                        <div className="jp-PluginPlayground-commandInsertSplit">
+                          <button
+                            className="jp-Button jp-mod-styled jp-mod-minimal jp-PluginPlayground-actionButton jp-PluginPlayground-commandInsertButton"
+                            type="button"
+                            onMouseDown={event => {
+                              event.preventDefault();
+                            }}
+                            onClick={() => {
+                              void this._insertCommand(
+                                command.id,
+                                commandInsertMode
+                              );
+                            }}
+                            disabled={!canInsertCommand}
+                            aria-label={
+                              isAICommandInsertMode
+                                ? `Prompt AI to insert command execution for ${command.id} (default)`
+                                : `Insert command execution for ${command.id} (default)`
+                            }
+                            title={
+                              isAICommandInsertMode
+                                ? 'Prompt AI to insert command execution (default)'
+                                : 'Insert command execution (default)'
+                            }
+                          >
+                            {React.createElement(addIcon.react, {
+                              tag: 'span',
+                              elementSize: 'normal',
+                              className: 'jp-PluginPlayground-actionIcon'
+                            })}
+                            {isAICommandInsertMode ? (
+                              <span
+                                className="jp-PluginPlayground-commandInsertAIBadge"
+                                aria-hidden="true"
+                              >
+                                {React.createElement(offlineBoltIcon.react, {
+                                  tag: 'span',
+                                  elementSize: 'small',
+                                  className:
+                                    'jp-PluginPlayground-commandInsertAIBadgeIcon'
+                                })}
+                                AI
+                              </span>
+                            ) : null}
+                          </button>
+                          <button
+                            className="jp-Button jp-mod-styled jp-mod-minimal jp-PluginPlayground-actionButton jp-PluginPlayground-commandInsertMenuButton"
+                            type="button"
+                            onMouseDown={event => {
+                              event.preventDefault();
+                            }}
+                            onClick={event => {
+                              this._openCommandInsertMenu(
+                                event.currentTarget,
+                                command.id
+                              );
+                            }}
+                            disabled={!canInsertCommand}
+                            aria-haspopup="menu"
+                            aria-label={`Choose command insertion mode for ${command.id}`}
+                            title="Choose command insertion mode"
+                          >
+                            {React.createElement(caretDownEmptyIcon.react, {
+                              tag: 'span',
+                              elementSize: 'normal',
+                              className: 'jp-PluginPlayground-actionIcon'
+                            })}
+                          </button>
+                        </div>
                         <button
                           className="jp-Button jp-mod-styled jp-mod-minimal jp-PluginPlayground-actionButton jp-PluginPlayground-argumentBadgeButton"
                           type="button"
@@ -764,6 +900,58 @@ export class TokenSidebar extends ReactWidget {
       await showDialog({
         title: 'Failed to insert import statement',
         body: `Could not insert import for "${tokenName}". ${message}`,
+        buttons: [Dialog.okButton()]
+      });
+    }
+  }
+
+  private _openCommandInsertMenu(
+    anchorButton: HTMLButtonElement,
+    commandId: string
+  ): void {
+    this._commandInsertMenu.clearItems();
+    this._commandInsertMenu.addItem({
+      command: COMMAND_INSERT_MENU_INSERT_ID,
+      args: { commandId }
+    });
+    this._commandInsertMenu.addItem({
+      command: COMMAND_INSERT_MENU_AI_ID,
+      args: { commandId }
+    });
+    const anchorRect = anchorButton.getBoundingClientRect();
+    const splitRect = anchorButton.parentElement?.getBoundingClientRect();
+    this._commandInsertMenu.open(
+      splitRect?.left ?? anchorRect.left,
+      anchorRect.bottom
+    );
+  }
+
+  private _commandIdFromMenuArgs(args: unknown): string {
+    return args && typeof args === 'object' && 'commandId' in args
+      ? typeof args.commandId === 'string'
+        ? args.commandId
+        : ''
+      : '';
+  }
+
+  private async _insertCommand(
+    commandId: string,
+    mode: CommandInsertMode
+  ): Promise<void> {
+    try {
+      await this._onInsertCommand(commandId, mode);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Unknown insertion error';
+      await showDialog({
+        title:
+          mode === 'ai'
+            ? 'Failed to open AI command insertion prompt'
+            : 'Failed to insert command execution',
+        body:
+          mode === 'ai'
+            ? `Could not prompt AI to insert command "${commandId}". ${message}`
+            : `Could not insert command "${commandId}". ${message}`,
         buttons: [Dialog.okButton()]
       });
     }

--- a/style/base.css
+++ b/style/base.css
@@ -145,22 +145,9 @@
   padding-right: 4px;
 }
 
-.jp-PluginPlayground-commandInsertAIBadge {
-  align-items: center;
-  background: var(--jp-brand-color1);
-  border-radius: 999px;
-  color: var(--jp-ui-inverse-font-color1);
-  display: inline-flex;
-  gap: 2px;
-  font-size: 9px;
-  font-weight: 700;
-  line-height: 1;
-  padding: 2px 4px;
-}
-
-.jp-PluginPlayground-commandInsertAIBadgeIcon {
-  height: 9px;
-  width: 9px;
+.jp-PluginPlayground-commandInsertAIMarkerIcon {
+  height: 11px;
+  width: 11px;
 }
 
 .jp-PluginPlayground-argumentBadgeButton {

--- a/style/base.css
+++ b/style/base.css
@@ -129,25 +129,50 @@
 
 .jp-PluginPlayground-commandInsertSplit {
   align-items: center;
+  border-radius: var(--jp-border-radius);
   display: inline-flex;
   gap: 0;
+  position: relative;
+}
+
+.jp-PluginPlayground-commandInsertSplit::after {
+  border: var(--jp-border-width) solid transparent;
+  border-radius: inherit;
+  content: '';
+  inset: calc(-1 * var(--jp-border-width));
+  pointer-events: none;
+  position: absolute;
+}
+
+.jp-PluginPlayground-commandInsertSplit:hover::after,
+.jp-PluginPlayground-commandInsertSplit:focus-within::after {
+  border-color: var(--jp-brand-color1);
 }
 
 .jp-PluginPlayground-commandInsertButton {
   min-width: 26px;
+  position: relative;
+  z-index: 1;
 }
 
 .jp-PluginPlayground-commandInsertMenuButton {
-  margin-left: calc(-1 * var(--jp-border-width));
+  z-index: 1;
+}
+
+.jp-PluginPlayground-commandInsertDropdownButton {
   border-left: var(--jp-border-width) solid var(--jp-border-color1);
-  min-width: 24px;
-  padding-left: 4px;
-  padding-right: 4px;
+  margin-left: calc(-1 * var(--jp-border-width));
+  min-width: 7px;
+  padding: 0 5px !important;
 }
 
 .jp-PluginPlayground-commandInsertAIMarkerIcon {
-  height: 11px;
-  width: 11px;
+  top: -5px;
+  height: 10px;
+  pointer-events: none;
+  position: absolute;
+  right: 7px;
+  width: 10px;
 }
 
 .jp-PluginPlayground-argumentBadgeButton {

--- a/style/base.css
+++ b/style/base.css
@@ -127,6 +127,42 @@
   justify-content: center;
 }
 
+.jp-PluginPlayground-commandInsertSplit {
+  align-items: center;
+  display: inline-flex;
+  gap: 0;
+}
+
+.jp-PluginPlayground-commandInsertButton {
+  min-width: 26px;
+}
+
+.jp-PluginPlayground-commandInsertMenuButton {
+  margin-left: calc(-1 * var(--jp-border-width));
+  border-left: var(--jp-border-width) solid var(--jp-border-color1);
+  min-width: 24px;
+  padding-left: 4px;
+  padding-right: 4px;
+}
+
+.jp-PluginPlayground-commandInsertAIBadge {
+  align-items: center;
+  background: var(--jp-brand-color1);
+  border-radius: 999px;
+  color: var(--jp-ui-inverse-font-color1);
+  display: inline-flex;
+  gap: 2px;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+  padding: 2px 4px;
+}
+
+.jp-PluginPlayground-commandInsertAIBadgeIcon {
+  height: 9px;
+  width: 9px;
+}
+
 .jp-PluginPlayground-argumentBadgeButton {
   position: relative;
 }

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -164,6 +164,32 @@ async function ensureMockJupyterLiteAIChat(
         }
       };
 
+      const app = window.jupyterapp as any;
+      const chatWidget = {
+        id: chatPanelId,
+        model: {
+          input: inputModel
+        }
+      };
+      app.__playgroundChatTracker = {
+        currentWidget: chatWidget,
+        find: (predicate: (widget: unknown) => boolean) =>
+          predicate(chatWidget) ? chatWidget : null
+      };
+      if (
+        !app.__playgroundOriginalResolveOptionalService &&
+        typeof app.resolveOptionalService === 'function'
+      ) {
+        app.__playgroundOriginalResolveOptionalService =
+          app.resolveOptionalService.bind(app);
+        app.resolveOptionalService = async (token: { name?: string }) => {
+          if (token?.name === '@jupyter/chat:IChatTracker') {
+            return app.__playgroundChatTracker;
+          }
+          return app.__playgroundOriginalResolveOptionalService(token);
+        };
+      }
+
       const shell = window.jupyterapp.shell as any;
       if (!shell.__playgroundOriginalWidgets) {
         shell.__playgroundOriginalWidgets = shell.widgets.bind(shell);
@@ -187,11 +213,7 @@ async function ensureMockJupyterLiteAIChat(
       }
       shell.__playgroundChatPanel = {
         id: chatPanelId,
-        current: {
-          model: {
-            input: inputModel
-          }
-        }
+        current: chatWidget
       };
 
       const commands = window.jupyterapp.commands;

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -131,7 +131,8 @@ async function ensureMockJupyterLiteAIChat(
       commandId: string;
       chatPanelId: string;
     }) => {
-      const inputSelector = '.jp-chat-input-textfield textarea';
+      const inputSelector =
+        '.jp-chat-input-textfield[data-playground-test="ai-input"] textarea';
       const ensureInput = (): HTMLTextAreaElement => {
         let input = document.querySelector(
           inputSelector
@@ -175,13 +176,11 @@ async function ensureMockJupyterLiteAIChat(
             shell.__playgroundChatPanel
           ) {
             const chatPanel = shell.__playgroundChatPanel;
-            if (
-              !originalWidgets.some(
-                (widget: any) => widget?.id === chatPanel.id
-              )
-            ) {
-              originalWidgets.push(chatPanel);
-            }
+            const widgetsWithoutChatPanel = originalWidgets.filter(
+              (widget: any) => widget?.id !== chatPanel.id
+            );
+            widgetsWithoutChatPanel.push(chatPanel);
+            return widgetsWithoutChatPanel[Symbol.iterator]();
           }
           return originalWidgets[Symbol.iterator]();
         };
@@ -196,6 +195,18 @@ async function ensureMockJupyterLiteAIChat(
       };
 
       const commands = window.jupyterapp.commands;
+      const commandRegistry = commands as any;
+      if (!commandRegistry.__playgroundOriginalExecute) {
+        commandRegistry.__playgroundOriginalExecute =
+          commands.execute.bind(commands);
+        commands.execute = async (id: string, args?: any) => {
+          if (id === commandId) {
+            ensureInput();
+            return undefined;
+          }
+          return commandRegistry.__playgroundOriginalExecute(id, args);
+        };
+      }
       if (!commands.hasCommand(commandId)) {
         commands.addCommand(commandId, {
           label: 'JupyterLite AI test command',
@@ -1513,7 +1524,9 @@ export default extension;
     return current.content.model.sharedModel.getSource();
   });
   const suggestedSnippet = `app.commands.execute('${LOAD_COMMAND}');`;
-  const chatInput = page.locator('.jp-chat-input-textfield textarea');
+  const chatInput = page.locator(
+    '.jp-chat-input-textfield[data-playground-test="ai-input"] textarea'
+  );
 
   const panel = await openSidebarPanel(page, TOKEN_SECTION_ID);
   await panel.getByRole('tab', { name: 'Commands', exact: true }).click();
@@ -1634,7 +1647,9 @@ export default [advanced, simple];
     return current.content.model.sharedModel.getSource();
   });
   const suggestedSnippet = `app.commands.execute('${LOAD_COMMAND}');`;
-  const chatInput = page.locator('.jp-chat-input-textfield textarea');
+  const chatInput = page.locator(
+    '.jp-chat-input-textfield[data-playground-test="ai-input"] textarea'
+  );
 
   const panel = await openSidebarPanel(page, TOKEN_SECTION_ID);
   await panel.getByRole('tab', { name: 'Commands', exact: true }).click();
@@ -1736,7 +1751,9 @@ export default plugins;
     return current.content.model.sharedModel.getSource();
   });
   const suggestedSnippet = `app.commands.execute('${LOAD_COMMAND}');`;
-  const chatInput = page.locator('.jp-chat-input-textfield textarea');
+  const chatInput = page.locator(
+    '.jp-chat-input-textfield[data-playground-test="ai-input"] textarea'
+  );
 
   const panel = await openSidebarPanel(page, TOKEN_SECTION_ID);
   await panel.getByRole('tab', { name: 'Commands', exact: true }).click();

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -1579,7 +1579,12 @@ export default extension;
   );
   await expect
     .poll(async () =>
-      chatInput.evaluate(input => input.selectionStart === input.value.length)
+      chatInput.evaluate(input => {
+        if (!(input instanceof HTMLTextAreaElement)) {
+          return false;
+        }
+        return input.selectionStart === input.value.length;
+      })
     )
     .toBe(true);
   await expect(chatInput).not.toHaveValue(

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -16,6 +16,7 @@ const LIST_COMMANDS_COMMAND = 'plugin-playground:list-commands';
 const LIST_EXAMPLES_COMMAND = 'plugin-playground:list-extension-examples';
 const TEST_PLUGIN_ID = 'playground-integration-test:plugin';
 const TEST_TOGGLE_COMMAND = 'playground-integration-test:toggle';
+const TEST_ARGS_COMMAND = 'playground-integration-test:with-args';
 const TEST_FILE = 'playground-integration-test.ts';
 const COMMAND_COMPLETION_FILE = 'command-completion.ts';
 const INVOKE_FILE_COMPLETER_COMMAND = 'completer:invoke-file';
@@ -1617,6 +1618,116 @@ export default extension;
     return current.content.model.sharedModel.getSource();
   });
   expect(sourceAfterSecondAction).toBe(sourceBefore);
+  await page.evaluate(() => {
+    document
+      .querySelector(
+        '.jp-chat-input-textfield[data-playground-test="ai-input"]'
+      )
+      ?.remove();
+  });
+});
+
+test('commands tab AI prompt includes command argument schema when available', async ({
+  page,
+  tmpPath
+}) => {
+  const editorPath = `${tmpPath}/command-sidebar-ai-prompt-args.ts`;
+
+  await page.contents.uploadContent(
+    `import { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application';
+
+const extension: JupyterFrontEndPlugin<void> = {
+  id: 'command-sidebar-ai-prompt-args:plugin',
+  autoStart: true,
+  activate: activate
+};
+
+function activate(app: JupyterFrontEnd): void {
+  const marker = 1;
+  void marker;
+}
+
+export default extension;
+`,
+    'text',
+    editorPath
+  );
+  await page.goto();
+  await page.filebrowser.open(editorPath);
+  expect(
+    await page.activity.activateTab('command-sidebar-ai-prompt-args.ts')
+  ).toBe(true);
+
+  await ensureMockJupyterLiteAIChat(page);
+
+  await page.evaluate((commandId: string) => {
+    const commands = window.jupyterapp.commands;
+    if (!commands.hasCommand(commandId)) {
+      commands.addCommand(commandId, {
+        label: 'Playground command with args',
+        usage: () =>
+          `app.commands.execute('${commandId}', { path: '/tmp/example.ts' });`,
+        describedBy: {
+          args: {
+            type: 'object',
+            required: ['path'],
+            properties: {
+              path: {
+                type: 'string',
+                description: 'Path to open.'
+              },
+              factory: {
+                type: 'string',
+                description: 'Widget factory name.'
+              }
+            }
+          }
+        },
+        execute: () => undefined
+      });
+    }
+  }, TEST_ARGS_COMMAND);
+
+  await page.evaluate(() => {
+    const current = window.jupyterapp.shell.currentWidget as FileEditorWidget;
+    const editor = current.content.editor;
+    editor.setCursorPosition({
+      line: 9,
+      column: 2
+    });
+    editor.focus();
+  });
+
+  const chatInput = page.locator(
+    '.jp-chat-input-textfield[data-playground-test="ai-input"] textarea'
+  );
+
+  const panel = await openSidebarPanel(page, TOKEN_SECTION_ID);
+  await panel.getByRole('tab', { name: 'Commands', exact: true }).click();
+  await panel.getByPlaceholder('Filter command ids').fill(TEST_ARGS_COMMAND);
+  const commandListItem = panel.locator('.jp-PluginPlayground-listItem');
+  await expect(commandListItem).toHaveCount(1);
+
+  const modeMenuButton = commandListItem.locator(
+    '.jp-PluginPlayground-commandInsertMenuButton'
+  );
+  const primaryInsertButton = commandListItem.locator(
+    '.jp-PluginPlayground-commandInsertButton'
+  );
+  await expect(modeMenuButton).toBeEnabled();
+  await expect(primaryInsertButton).toBeEnabled();
+  await modeMenuButton.click();
+  await page.getByRole('menuitem', { name: 'Prompt AI to insert' }).click();
+  await primaryInsertButton.click();
+
+  await expect(chatInput).toHaveValue(
+    new RegExp(escapeRegExp(`Command ID: ${TEST_ARGS_COMMAND}`))
+  );
+  await expect(chatInput).toHaveValue(/Command Arguments:/);
+  await expect(chatInput).toHaveValue(/Arguments Schema:/);
+  await expect(chatInput).toHaveValue(/"path"/);
+  await expect(chatInput).toHaveValue(/"factory"/);
+
   await page.evaluate(() => {
     document
       .querySelector(

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -19,6 +19,7 @@ const TEST_TOGGLE_COMMAND = 'playground-integration-test:toggle';
 const TEST_FILE = 'playground-integration-test.ts';
 const COMMAND_COMPLETION_FILE = 'command-completion.ts';
 const INVOKE_FILE_COMPLETER_COMMAND = 'completer:invoke-file';
+const JUPYTERLITE_AI_OPEN_CHAT_COMMAND = '@jupyterlite/ai:open-chat';
 const PLAYGROUND_SIDEBAR_ID = 'jp-plugin-playground-sidebar';
 const TOKEN_SECTION_ID = 'jp-plugin-token-sidebar';
 const EXAMPLE_SECTION_ID = 'jp-plugin-example-sidebar';
@@ -116,6 +117,38 @@ async function focusActiveEditor(page: IJupyterLabPageFixture): Promise<void> {
     const current = window.jupyterapp.shell.currentWidget as FileEditorWidget;
     current.content.editor.focus();
   });
+}
+
+async function ensureMockJupyterLiteAIChat(
+  page: IJupyterLabPageFixture
+): Promise<void> {
+  await page.evaluate((commandId: string) => {
+    const inputSelector = '.jp-chat-input-textfield textarea';
+    const ensureInput = (): void => {
+      if (document.querySelector(inputSelector)) {
+        return;
+      }
+      const wrapper = document.createElement('div');
+      wrapper.className = 'jp-chat-input-textfield';
+      wrapper.setAttribute('data-playground-test', 'ai-input');
+      wrapper.appendChild(document.createElement('textarea'));
+      document.body.prepend(wrapper);
+    };
+
+    const commands = window.jupyterapp.commands;
+    if (!commands.hasCommand(commandId)) {
+      commands.addCommand(commandId, {
+        label: 'JupyterLite AI test command',
+        describedBy: { args: null },
+        execute: () => {
+          ensureInput();
+          return undefined;
+        }
+      });
+    }
+
+    ensureInput();
+  }, JUPYTERLITE_AI_OPEN_CHAT_COMMAND);
 }
 
 test('registers plugin playground commands', async ({ page }) => {
@@ -1258,6 +1291,389 @@ test('commands tab lists and filters available commands', async ({ page }) => {
   await expect(
     panel.locator('.jp-PluginPlayground-commandArgumentsText')
   ).toContainText(/(Usage:|Arguments Schema:)/);
+});
+
+test('commands tab inserts command execution at cursor position', async ({
+  page,
+  tmpPath
+}) => {
+  const editorPath = `${tmpPath}/command-sidebar-insert.ts`;
+
+  await page.contents.uploadContent(
+    `import { JupyterFrontEnd } from '@jupyterlab/application';
+
+const run = (application: JupyterFrontEnd) => {
+
+  const marker = 1;
+  void marker;
+};
+`,
+    'text',
+    editorPath
+  );
+  await page.goto();
+  await page.filebrowser.open(editorPath);
+  expect(await page.activity.activateTab('command-sidebar-insert.ts')).toBe(
+    true
+  );
+
+  await page.evaluate(() => {
+    const current = window.jupyterapp.shell.currentWidget as FileEditorWidget;
+    const editor = current.content.editor;
+    editor.setCursorPosition({
+      line: 3,
+      column: 2
+    });
+    editor.focus();
+  });
+
+  const expectedSourceAfterInsert = await page.evaluate((commandId: string) => {
+    const current = window.jupyterapp.shell.currentWidget as FileEditorWidget;
+    const editor = current.content.editor;
+    const source = current.content.model.sharedModel.getSource();
+    const insertionOffset = editor.getOffsetAt(editor.getCursorPosition());
+    const inserted = `app.commands.execute('${commandId}');`;
+    return `${source.slice(0, insertionOffset)}${inserted}${source.slice(
+      insertionOffset
+    )}`;
+  }, LOAD_COMMAND);
+
+  const panel = await openSidebarPanel(page, TOKEN_SECTION_ID);
+  await panel.getByRole('tab', { name: 'Commands', exact: true }).click();
+
+  const filterInput = panel.getByPlaceholder('Filter command ids');
+  await filterInput.fill(LOAD_COMMAND);
+  const commandListItem = panel.locator('.jp-PluginPlayground-listItem');
+  await expect(commandListItem).toHaveCount(1);
+
+  const insertButton = commandListItem.locator(
+    '.jp-PluginPlayground-commandInsertButton'
+  );
+  await expect(insertButton).toBeEnabled();
+  await insertButton.click();
+
+  await page.waitForFunction((expected: string) => {
+    const current = window.jupyterapp.shell.currentWidget as FileEditorWidget;
+    const source = current.content.model.sharedModel.getSource();
+    return source === expected;
+  }, expectedSourceAfterInsert);
+});
+
+test('commands tab can prompt JupyterLite AI and remember last insertion mode', async ({
+  page,
+  tmpPath
+}) => {
+  const editorPath = `${tmpPath}/command-sidebar-ai-prompt.ts`;
+
+  await page.contents.uploadContent(
+    `import { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application';
+
+const extension: JupyterFrontEndPlugin<void> = {
+  id: 'command-sidebar-ai-prompt:plugin',
+  autoStart: true,
+  activate: activate
+};
+
+function activate(app: JupyterFrontEnd): void {
+  const marker = 1;
+  void marker;
+};
+
+export default extension;
+`,
+    'text',
+    editorPath
+  );
+  await page.goto();
+  await page.filebrowser.open(editorPath);
+  expect(await page.activity.activateTab('command-sidebar-ai-prompt.ts')).toBe(
+    true
+  );
+
+  await ensureMockJupyterLiteAIChat(page);
+
+  await page.evaluate(() => {
+    const current = window.jupyterapp.shell.currentWidget as FileEditorWidget;
+    const editor = current.content.editor;
+    editor.setCursorPosition({
+      line: 9,
+      column: 2
+    });
+    editor.focus();
+  });
+
+  const sourceBefore = await page.evaluate(() => {
+    const current = window.jupyterapp.shell.currentWidget as FileEditorWidget;
+    return current.content.model.sharedModel.getSource();
+  });
+  const suggestedSnippet = `app.commands.execute('${LOAD_COMMAND}');`;
+  const chatInput = page.locator('.jp-chat-input-textfield textarea');
+
+  const panel = await openSidebarPanel(page, TOKEN_SECTION_ID);
+  await panel.getByRole('tab', { name: 'Commands', exact: true }).click();
+  await panel.getByPlaceholder('Filter command ids').fill(LOAD_COMMAND);
+  const commandListItem = panel.locator('.jp-PluginPlayground-listItem');
+  await expect(commandListItem).toHaveCount(1);
+
+  const modeMenuButton = commandListItem.locator(
+    '.jp-PluginPlayground-commandInsertMenuButton'
+  );
+  await expect(modeMenuButton).toBeEnabled();
+  await modeMenuButton.click();
+  await page.getByRole('menuitem', { name: 'Prompt AI to insert' }).click();
+
+  await expect(chatInput).toHaveValue(
+    new RegExp(escapeRegExp(`Command ID: ${LOAD_COMMAND}`))
+  );
+  await expect(chatInput).toHaveValue(
+    new RegExp(escapeRegExp(`Suggested command call: ${suggestedSnippet}`))
+  );
+  await expect(chatInput).toHaveValue(
+    new RegExp(escapeRegExp('Use the activate() app variable: app.'))
+  );
+  await expect(chatInput).not.toHaveValue(
+    new RegExp(
+      escapeRegExp(
+        'If app is missing, add JupyterFrontEnd import and declare activate(app: JupyterFrontEnd, ...).'
+      )
+    )
+  );
+
+  const sourceAfterAIAction = await page.evaluate(() => {
+    const current = window.jupyterapp.shell.currentWidget as FileEditorWidget;
+    return current.content.model.sharedModel.getSource();
+  });
+  expect(sourceAfterAIAction).toBe(sourceBefore);
+
+  await chatInput.fill('');
+
+  const primaryInsertButton = commandListItem.locator(
+    '.jp-PluginPlayground-commandInsertButton'
+  );
+  await primaryInsertButton.click();
+
+  await expect(chatInput).toHaveValue(
+    new RegExp(escapeRegExp(`Command ID: ${LOAD_COMMAND}`))
+  );
+  await expect(chatInput).toHaveValue(
+    new RegExp(escapeRegExp(`Suggested command call: ${suggestedSnippet}`))
+  );
+
+  const sourceAfterSecondAction = await page.evaluate(() => {
+    const current = window.jupyterapp.shell.currentWidget as FileEditorWidget;
+    return current.content.model.sharedModel.getSource();
+  });
+  expect(sourceAfterSecondAction).toBe(sourceBefore);
+  await page.evaluate(() => {
+    document
+      .querySelector(
+        '.jp-chat-input-textfield[data-playground-test="ai-input"]'
+      )
+      ?.remove();
+  });
+});
+
+test('commands tab AI prompt detects activate app in default-export plugin arrays', async ({
+  page,
+  tmpPath
+}) => {
+  const editorPath = `${tmpPath}/command-sidebar-ai-prompt-array.ts`;
+
+  await page.contents.uploadContent(
+    `import { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application';
+
+const simple: JupyterFrontEndPlugin<void> = {
+  id: 'command-sidebar-ai-prompt-array:simple',
+  autoStart: true,
+  activate: (app: JupyterFrontEnd) => {
+    const marker = 1;
+    void marker;
+  }
+};
+
+const advanced: JupyterFrontEndPlugin<void> = {
+  id: 'command-sidebar-ai-prompt-array:advanced',
+  autoStart: true,
+  activate: (app: JupyterFrontEnd, palette: unknown) => {
+    void app;
+    void palette;
+  }
+};
+
+export default [advanced, simple];
+`,
+    'text',
+    editorPath
+  );
+  await page.goto();
+  await page.filebrowser.open(editorPath);
+  expect(
+    await page.activity.activateTab('command-sidebar-ai-prompt-array.ts')
+  ).toBe(true);
+
+  await ensureMockJupyterLiteAIChat(page);
+
+  await page.evaluate(() => {
+    const current = window.jupyterapp.shell.currentWidget as FileEditorWidget;
+    const editor = current.content.editor;
+    editor.setCursorPosition({
+      line: 6,
+      column: 4
+    });
+    editor.focus();
+  });
+
+  const sourceBefore = await page.evaluate(() => {
+    const current = window.jupyterapp.shell.currentWidget as FileEditorWidget;
+    return current.content.model.sharedModel.getSource();
+  });
+  const suggestedSnippet = `app.commands.execute('${LOAD_COMMAND}');`;
+  const chatInput = page.locator('.jp-chat-input-textfield textarea');
+
+  const panel = await openSidebarPanel(page, TOKEN_SECTION_ID);
+  await panel.getByRole('tab', { name: 'Commands', exact: true }).click();
+  await panel.getByPlaceholder('Filter command ids').fill(LOAD_COMMAND);
+  const commandListItem = panel.locator('.jp-PluginPlayground-listItem');
+  await expect(commandListItem).toHaveCount(1);
+
+  const modeMenuButton = commandListItem.locator(
+    '.jp-PluginPlayground-commandInsertMenuButton'
+  );
+  await expect(modeMenuButton).toBeEnabled();
+  await modeMenuButton.click();
+  await page.getByRole('menuitem', { name: 'Prompt AI to insert' }).click();
+
+  await expect(chatInput).toHaveValue(
+    new RegExp(escapeRegExp(`Command ID: ${LOAD_COMMAND}`))
+  );
+  await expect(chatInput).toHaveValue(
+    new RegExp(escapeRegExp(`Suggested command call: ${suggestedSnippet}`))
+  );
+  await expect(chatInput).toHaveValue(
+    new RegExp(escapeRegExp('Use the activate() app variable: app.'))
+  );
+  await expect(chatInput).not.toHaveValue(
+    new RegExp(
+      escapeRegExp(
+        'If app is missing, add JupyterFrontEnd import and declare activate(app: JupyterFrontEnd, ...).'
+      )
+    )
+  );
+
+  const sourceAfterAIAction = await page.evaluate(() => {
+    const current = window.jupyterapp.shell.currentWidget as FileEditorWidget;
+    return current.content.model.sharedModel.getSource();
+  });
+  expect(sourceAfterAIAction).toBe(sourceBefore);
+  await page.evaluate(() => {
+    document
+      .querySelector(
+        '.jp-chat-input-textfield[data-playground-test="ai-input"]'
+      )
+      ?.remove();
+  });
+});
+
+test('commands tab AI prompt detects activate app in exported plugin array variables', async ({
+  page,
+  tmpPath
+}) => {
+  const editorPath = `${tmpPath}/command-sidebar-ai-prompt-plugins-var.ts`;
+
+  await page.contents.uploadContent(
+    `import { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application';
+
+const simple: JupyterFrontEndPlugin<void> = {
+  id: 'command-sidebar-ai-prompt-plugins-var:simple',
+  autoStart: true,
+  activate: (app: JupyterFrontEnd) => {
+    const marker = 1;
+    void marker;
+  }
+};
+
+const advanced: JupyterFrontEndPlugin<void> = {
+  id: 'command-sidebar-ai-prompt-plugins-var:advanced',
+  autoStart: true,
+  activate: (app: JupyterFrontEnd, palette: unknown) => {
+    void app;
+    void palette;
+  }
+};
+
+const plugins: JupyterFrontEndPlugin<void>[] = [advanced, simple];
+export default plugins;
+`,
+    'text',
+    editorPath
+  );
+  await page.goto();
+  await page.filebrowser.open(editorPath);
+  expect(
+    await page.activity.activateTab('command-sidebar-ai-prompt-plugins-var.ts')
+  ).toBe(true);
+
+  await ensureMockJupyterLiteAIChat(page);
+
+  await page.evaluate(() => {
+    const current = window.jupyterapp.shell.currentWidget as FileEditorWidget;
+    const editor = current.content.editor;
+    editor.setCursorPosition({
+      line: 6,
+      column: 4
+    });
+    editor.focus();
+  });
+
+  const sourceBefore = await page.evaluate(() => {
+    const current = window.jupyterapp.shell.currentWidget as FileEditorWidget;
+    return current.content.model.sharedModel.getSource();
+  });
+  const suggestedSnippet = `app.commands.execute('${LOAD_COMMAND}');`;
+  const chatInput = page.locator('.jp-chat-input-textfield textarea');
+
+  const panel = await openSidebarPanel(page, TOKEN_SECTION_ID);
+  await panel.getByRole('tab', { name: 'Commands', exact: true }).click();
+  await panel.getByPlaceholder('Filter command ids').fill(LOAD_COMMAND);
+  const commandListItem = panel.locator('.jp-PluginPlayground-listItem');
+  await expect(commandListItem).toHaveCount(1);
+
+  const modeMenuButton = commandListItem.locator(
+    '.jp-PluginPlayground-commandInsertMenuButton'
+  );
+  await expect(modeMenuButton).toBeEnabled();
+  await modeMenuButton.click();
+  await page.getByRole('menuitem', { name: 'Prompt AI to insert' }).click();
+
+  await expect(chatInput).toHaveValue(
+    new RegExp(escapeRegExp(`Command ID: ${LOAD_COMMAND}`))
+  );
+  await expect(chatInput).toHaveValue(
+    new RegExp(escapeRegExp(`Suggested command call: ${suggestedSnippet}`))
+  );
+  await expect(chatInput).toHaveValue(
+    new RegExp(escapeRegExp('Use the activate() app variable: app.'))
+  );
+  await expect(chatInput).not.toHaveValue(
+    new RegExp(
+      escapeRegExp(
+        'If app is missing, add JupyterFrontEnd import and declare activate(app: JupyterFrontEnd, ...).'
+      )
+    )
+  );
+
+  const sourceAfterAIAction = await page.evaluate(() => {
+    const current = window.jupyterapp.shell.currentWidget as FileEditorWidget;
+    return current.content.model.sharedModel.getSource();
+  });
+  expect(sourceAfterAIAction).toBe(sourceBefore);
+  await page.evaluate(() => {
+    document
+      .querySelector(
+        '.jp-chat-input-textfield[data-playground-test="ai-input"]'
+      )
+      ?.remove();
+  });
 });
 
 test('command completer suggests command ids inside execute calls', async ({

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -20,6 +20,7 @@ const TEST_FILE = 'playground-integration-test.ts';
 const COMMAND_COMPLETION_FILE = 'command-completion.ts';
 const INVOKE_FILE_COMPLETER_COMMAND = 'completer:invoke-file';
 const JUPYTERLITE_AI_OPEN_CHAT_COMMAND = '@jupyterlite/ai:open-chat';
+const JUPYTERLITE_AI_CHAT_PANEL_ID = '@jupyterlite/ai:chat-panel';
 const PLAYGROUND_SIDEBAR_ID = 'jp-plugin-playground-sidebar';
 const TOKEN_SECTION_ID = 'jp-plugin-token-sidebar';
 const EXAMPLE_SECTION_ID = 'jp-plugin-example-sidebar';
@@ -122,33 +123,97 @@ async function focusActiveEditor(page: IJupyterLabPageFixture): Promise<void> {
 async function ensureMockJupyterLiteAIChat(
   page: IJupyterLabPageFixture
 ): Promise<void> {
-  await page.evaluate((commandId: string) => {
-    const inputSelector = '.jp-chat-input-textfield textarea';
-    const ensureInput = (): void => {
-      if (document.querySelector(inputSelector)) {
-        return;
-      }
-      const wrapper = document.createElement('div');
-      wrapper.className = 'jp-chat-input-textfield';
-      wrapper.setAttribute('data-playground-test', 'ai-input');
-      wrapper.appendChild(document.createElement('textarea'));
-      document.body.prepend(wrapper);
-    };
-
-    const commands = window.jupyterapp.commands;
-    if (!commands.hasCommand(commandId)) {
-      commands.addCommand(commandId, {
-        label: 'JupyterLite AI test command',
-        describedBy: { args: null },
-        execute: () => {
-          ensureInput();
-          return undefined;
+  await page.evaluate(
+    ({
+      commandId,
+      chatPanelId
+    }: {
+      commandId: string;
+      chatPanelId: string;
+    }) => {
+      const inputSelector = '.jp-chat-input-textfield textarea';
+      const ensureInput = (): HTMLTextAreaElement => {
+        let input = document.querySelector(
+          inputSelector
+        ) as HTMLTextAreaElement | null;
+        if (input) {
+          return input;
         }
-      });
-    }
+        const wrapper = document.createElement('div');
+        wrapper.className = 'jp-chat-input-textfield';
+        wrapper.setAttribute('data-playground-test', 'ai-input');
+        input = document.createElement('textarea');
+        wrapper.appendChild(input);
+        document.body.prepend(wrapper);
+        return input;
+      };
 
-    ensureInput();
-  }, JUPYTERLITE_AI_OPEN_CHAT_COMMAND);
+      const inputModel = {
+        get value(): string {
+          return ensureInput().value;
+        },
+        set value(nextValue: string) {
+          const input = ensureInput();
+          input.value = nextValue;
+          input.dispatchEvent(new Event('input', { bubbles: true }));
+          input.dispatchEvent(new Event('change', { bubbles: true }));
+        },
+        focus: () => {
+          ensureInput().focus();
+        }
+      };
+
+      const shell = window.jupyterapp.shell as any;
+      if (!shell.__playgroundOriginalWidgets) {
+        shell.__playgroundOriginalWidgets = shell.widgets.bind(shell);
+        shell.widgets = (area: string) => {
+          const originalWidgets = Array.from(
+            shell.__playgroundOriginalWidgets(area)
+          );
+          if (
+            (area === 'left' || area === 'right') &&
+            shell.__playgroundChatPanel
+          ) {
+            const chatPanel = shell.__playgroundChatPanel;
+            if (
+              !originalWidgets.some(
+                (widget: any) => widget?.id === chatPanel.id
+              )
+            ) {
+              originalWidgets.push(chatPanel);
+            }
+          }
+          return originalWidgets[Symbol.iterator]();
+        };
+      }
+      shell.__playgroundChatPanel = {
+        id: chatPanelId,
+        current: {
+          model: {
+            input: inputModel
+          }
+        }
+      };
+
+      const commands = window.jupyterapp.commands;
+      if (!commands.hasCommand(commandId)) {
+        commands.addCommand(commandId, {
+          label: 'JupyterLite AI test command',
+          describedBy: { args: null },
+          execute: () => {
+            ensureInput();
+            return undefined;
+          }
+        });
+      }
+
+      ensureInput();
+    },
+    {
+      commandId: JUPYTERLITE_AI_OPEN_CHAT_COMMAND,
+      chatPanelId: JUPYTERLITE_AI_CHAT_PANEL_ID
+    }
+  );
 }
 
 test('registers plugin playground commands', async ({ page }) => {

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -968,15 +968,16 @@ export default plugin;
   const separatorIndex = tokenName.indexOf(':');
   const packageName = tokenName.slice(0, separatorIndex).trim();
   const tokenSymbol = tokenName.slice(separatorIndex + 1).trim();
-  const expectedImport = `import { ${tokenSymbol} } from '${packageName}';`;
   const expectedDependency = `requires: [${tokenSymbol}]`;
   const expectedParameterName = parameterNameFromToken(tokenSymbol);
   const expectedTokenPattern = escapeRegExp(tokenSymbol);
   const expectedParameterPattern = escapeRegExp(expectedParameterName);
+  const expectedPackagePattern = escapeRegExp(packageName);
+  const expectedImportPattern = `import\\s*\\{[^}]*\\b${expectedTokenPattern}\\b[^}]*\\}\\s*from\\s*['"]${expectedPackagePattern}['"]\\s*;`;
 
   await page.waitForFunction(
     ({
-      expectedImportStatement,
+      expectedImportSourcePattern,
       expectedDependencyStatement,
       expectedToken,
       expectedParameter
@@ -991,13 +992,13 @@ export default plugin;
         `activate:\\s*\\(app:\\s*JupyterFrontEnd,\\s*${expectedParameter}\\s*:\\s*${expectedToken}\\)`
       );
       return (
-        source.startsWith(expectedImportStatement) &&
+        new RegExp(expectedImportSourcePattern).test(source) &&
         source.includes(expectedDependencyStatement) &&
         activatePattern.test(source)
       );
     },
     {
-      expectedImportStatement: expectedImport,
+      expectedImportSourcePattern: expectedImportPattern,
       expectedDependencyStatement: expectedDependency,
       expectedToken: expectedTokenPattern,
       expectedParameter: expectedParameterPattern
@@ -1012,24 +1013,41 @@ export default plugin;
   });
   await importButton.click();
   await page.waitForFunction(
-    ({ expectedImportStatement, expectedDependencyStatement }) => {
+    ({ expectedPackage, expectedTokenSymbol, expectedDependencyStatement }) => {
       const current = window.jupyterapp.shell
         .currentWidget as FileEditorWidget | null;
       const source = current?.content.model.sharedModel.getSource();
       if (typeof source !== 'string') {
         return false;
       }
+      const packageImportPattern = new RegExp(
+        `import\\s*\\{([^}]*)\\}\\s*from\\s*['"]${expectedPackage}['"]\\s*;`,
+        'g'
+      );
+      let canonicalSpecifierCount = 0;
+      let match = packageImportPattern.exec(source);
+      while (match) {
+        const specifiers = match[1]
+          .split(',')
+          .map(specifier => specifier.trim())
+          .filter(specifier => specifier.length > 0);
+        canonicalSpecifierCount += specifiers.filter(
+          specifier => specifier === expectedTokenSymbol
+        ).length;
+        match = packageImportPattern.exec(source);
+      }
       const highlightedLines = document.querySelectorAll(
         '.jp-FileEditor .jp-PluginPlayground-lineHighlight'
       ).length;
       return (
-        source.split(expectedImportStatement).length - 1 === 1 &&
+        canonicalSpecifierCount === 1 &&
         source.split(expectedDependencyStatement).length - 1 === 1 &&
         highlightedLines >= 2
       );
     },
     {
-      expectedImportStatement: expectedImport,
+      expectedPackage: expectedPackagePattern,
+      expectedTokenSymbol: tokenSymbol,
       expectedDependencyStatement: expectedDependency
     }
   );
@@ -1096,12 +1114,13 @@ export default plugin;
   await expect(importButton).toBeEnabled();
   await importButton.click();
 
-  const expectedImport = `import { ${tokenSymbol} } from '${packageName}';`;
-  const aliasImport = `import { ${tokenSymbol} as existingAlias } from '${packageName}';`;
+  const expectedPackagePattern = escapeRegExp(packageName);
+  const aliasImport = `${tokenSymbol} as existingAlias`;
   const expectedDependency = `requires: [${tokenSymbol}]`;
   await page.waitForFunction(
     ({
-      expectedImportStatement,
+      expectedPackage,
+      expectedTokenSymbol,
       aliasImportStatement,
       expectedDependencyStatement
     }) => {
@@ -1111,14 +1130,34 @@ export default plugin;
       if (typeof source !== 'string') {
         return false;
       }
+      const packageImportPattern = new RegExp(
+        `import\\s*\\{([^}]*)\\}\\s*from\\s*['"]${expectedPackage}['"]\\s*;`,
+        'g'
+      );
+      let hasAliasImport = false;
+      let canonicalSpecifierCount = 0;
+      let match = packageImportPattern.exec(source);
+      while (match) {
+        const specifiers = match[1]
+          .split(',')
+          .map(specifier => specifier.trim())
+          .filter(specifier => specifier.length > 0);
+        hasAliasImport =
+          hasAliasImport || specifiers.includes(aliasImportStatement);
+        canonicalSpecifierCount += specifiers.filter(
+          specifier => specifier === expectedTokenSymbol
+        ).length;
+        match = packageImportPattern.exec(source);
+      }
       return (
-        source.startsWith(expectedImportStatement) &&
-        source.includes(aliasImportStatement) &&
+        hasAliasImport &&
+        canonicalSpecifierCount >= 1 &&
         source.includes(expectedDependencyStatement)
       );
     },
     {
-      expectedImportStatement: expectedImport,
+      expectedPackage: expectedPackagePattern,
+      expectedTokenSymbol: tokenSymbol,
       aliasImportStatement: aliasImport,
       expectedDependencyStatement: expectedDependency
     }
@@ -1240,10 +1279,12 @@ export default plugin;
   const separatorIndex = tokenName.indexOf(':');
   const packageName = tokenName.slice(0, separatorIndex).trim();
   const tokenSymbol = tokenName.slice(separatorIndex + 1).trim();
-  const expectedImport = `import { ${tokenSymbol} } from '${packageName}';`;
+  const expectedPackagePattern = escapeRegExp(packageName);
+  const expectedTokenPattern = escapeRegExp(tokenSymbol);
+  const expectedImportPattern = `import\\s*\\{[^}]*\\b${expectedTokenPattern}\\b[^}]*\\}\\s*from\\s*['"]${expectedPackagePattern}['"]\\s*;`;
 
   await page.waitForFunction(
-    ({ expectedImportStatement, token }) => {
+    ({ expectedImportSourcePattern, token }) => {
       const current = window.jupyterapp.shell
         .currentWidget as FileEditorWidget | null;
       const source = current?.content.model.sharedModel.getSource();
@@ -1251,7 +1292,7 @@ export default plugin;
         return false;
       }
       return (
-        source.startsWith(expectedImportStatement) &&
+        new RegExp(expectedImportSourcePattern).test(source) &&
         source.includes('requires: requiredServices') &&
         source.split('requires:').length - 1 === 1 &&
         !source.includes(`requires: [${token}]`) &&
@@ -1259,7 +1300,7 @@ export default plugin;
       );
     },
     {
-      expectedImportStatement: expectedImport,
+      expectedImportSourcePattern: expectedImportPattern,
       token: tokenSymbol
     }
   );

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -1537,9 +1537,14 @@ export default extension;
   const modeMenuButton = commandListItem.locator(
     '.jp-PluginPlayground-commandInsertMenuButton'
   );
+  const primaryInsertButton = commandListItem.locator(
+    '.jp-PluginPlayground-commandInsertButton'
+  );
   await expect(modeMenuButton).toBeEnabled();
+  await expect(primaryInsertButton).toBeEnabled();
   await modeMenuButton.click();
   await page.getByRole('menuitem', { name: 'Prompt AI to insert' }).click();
+  await primaryInsertButton.click();
 
   await expect(chatInput).toHaveValue(
     new RegExp(escapeRegExp(`Command ID: ${LOAD_COMMAND}`))
@@ -1566,9 +1571,6 @@ export default extension;
 
   await chatInput.fill('');
 
-  const primaryInsertButton = commandListItem.locator(
-    '.jp-PluginPlayground-commandInsertButton'
-  );
   await primaryInsertButton.click();
 
   await expect(chatInput).toHaveValue(
@@ -1660,9 +1662,14 @@ export default [advanced, simple];
   const modeMenuButton = commandListItem.locator(
     '.jp-PluginPlayground-commandInsertMenuButton'
   );
+  const primaryInsertButton = commandListItem.locator(
+    '.jp-PluginPlayground-commandInsertButton'
+  );
   await expect(modeMenuButton).toBeEnabled();
+  await expect(primaryInsertButton).toBeEnabled();
   await modeMenuButton.click();
   await page.getByRole('menuitem', { name: 'Prompt AI to insert' }).click();
+  await primaryInsertButton.click();
 
   await expect(chatInput).toHaveValue(
     new RegExp(escapeRegExp(`Command ID: ${LOAD_COMMAND}`))
@@ -1764,9 +1771,14 @@ export default plugins;
   const modeMenuButton = commandListItem.locator(
     '.jp-PluginPlayground-commandInsertMenuButton'
   );
+  const primaryInsertButton = commandListItem.locator(
+    '.jp-PluginPlayground-commandInsertButton'
+  );
   await expect(modeMenuButton).toBeEnabled();
+  await expect(primaryInsertButton).toBeEnabled();
   await modeMenuButton.click();
   await page.getByRole('menuitem', { name: 'Prompt AI to insert' }).click();
+  await primaryInsertButton.click();
 
   await expect(chatInput).toHaveValue(
     new RegExp(escapeRegExp(`Command ID: ${LOAD_COMMAND}`))

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -1577,6 +1577,11 @@ export default extension;
   await expect(chatInput).toHaveValue(
     new RegExp(escapeRegExp('Use the activate() app variable: app.'))
   );
+  await expect
+    .poll(async () =>
+      chatInput.evaluate(input => input.selectionStart === input.value.length)
+    )
+    .toBe(true);
   await expect(chatInput).not.toHaveValue(
     new RegExp(
       escapeRegExp(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1068,20 +1068,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/attachments@npm:^4.5.5":
-  version: 4.5.5
-  resolution: "@jupyterlab/attachments@npm:4.5.5"
-  dependencies:
-    "@jupyterlab/nbformat": ^4.5.5
-    "@jupyterlab/observables": ^5.5.5
-    "@jupyterlab/rendermime": ^4.5.5
-    "@jupyterlab/rendermime-interfaces": ^3.13.5
-    "@lumino/disposable": ^2.1.5
-    "@lumino/signaling": ^2.1.5
-  checksum: 2ace675bc222ab11c3c1967efdfb9f1f87d1e50da3beb9428f62a4e78e40278249f2b56bf04c9118e4736df88233c1fd351a43826cd5be74d62498fe03de740f
-  languageName: node
-  linkType: hard
-
 "@jupyterlab/attachments@npm:^4.5.6":
   version: 4.5.6
   resolution: "@jupyterlab/attachments@npm:4.5.6"
@@ -1158,43 +1144,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/cells@npm:^4.5.0, @jupyterlab/cells@npm:^4.5.5":
-  version: 4.5.5
-  resolution: "@jupyterlab/cells@npm:4.5.5"
-  dependencies:
-    "@codemirror/state": ^6.5.4
-    "@codemirror/view": ^6.39.14
-    "@jupyter/ydoc": ^3.1.0
-    "@jupyterlab/apputils": ^4.6.5
-    "@jupyterlab/attachments": ^4.5.5
-    "@jupyterlab/codeeditor": ^4.5.5
-    "@jupyterlab/codemirror": ^4.5.5
-    "@jupyterlab/coreutils": ^6.5.5
-    "@jupyterlab/documentsearch": ^4.5.5
-    "@jupyterlab/filebrowser": ^4.5.5
-    "@jupyterlab/nbformat": ^4.5.5
-    "@jupyterlab/observables": ^5.5.5
-    "@jupyterlab/outputarea": ^4.5.5
-    "@jupyterlab/rendermime": ^4.5.5
-    "@jupyterlab/services": ^7.5.5
-    "@jupyterlab/toc": ^6.5.5
-    "@jupyterlab/translation": ^4.5.5
-    "@jupyterlab/ui-components": ^4.5.5
-    "@lumino/algorithm": ^2.0.4
-    "@lumino/coreutils": ^2.2.2
-    "@lumino/domutils": ^2.0.4
-    "@lumino/dragdrop": ^2.1.8
-    "@lumino/messaging": ^2.0.4
-    "@lumino/polling": ^2.1.5
-    "@lumino/signaling": ^2.1.5
-    "@lumino/virtualdom": ^2.0.4
-    "@lumino/widgets": ^2.7.5
-    react: ^18.2.0
-  checksum: b6bd568070940458cbf9991b8c70ff299689f6742a5a79c57d0627a142ecb3fb604f5a35fadb3e9e3feb1d3b302ca5d05175f4a6326049def2eb40d967716b72
-  languageName: node
-  linkType: hard
-
-"@jupyterlab/cells@npm:^4.5.6":
+"@jupyterlab/cells@npm:^4.5.0, @jupyterlab/cells@npm:^4.5.5, @jupyterlab/cells@npm:^4.5.6":
   version: 4.5.6
   resolution: "@jupyterlab/cells@npm:4.5.6"
   dependencies:
@@ -1254,7 +1204,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/codemirror@npm:^4.2.0, @jupyterlab/codemirror@npm:^4.5.6":
+"@jupyterlab/codemirror@npm:^4.2.0, @jupyterlab/codemirror@npm:^4.5.5, @jupyterlab/codemirror@npm:^4.5.6":
   version: 4.5.6
   resolution: "@jupyterlab/codemirror@npm:4.5.6"
   dependencies:
@@ -1293,48 +1243,6 @@ __metadata:
     "@lumino/signaling": ^2.1.5
     yjs: ^13.5.40
   checksum: 41ac99b7fc675875c7eece4b24f779cd7e26b525cb9646c7ffbeeb70c0c5d6e1221175d12dc62f3b0dcbdb9ee5cef9dbc60b4227f2a950c62502249e4dca7f40
-  languageName: node
-  linkType: hard
-
-"@jupyterlab/codemirror@npm:^4.5.5":
-  version: 4.5.5
-  resolution: "@jupyterlab/codemirror@npm:4.5.5"
-  dependencies:
-    "@codemirror/autocomplete": ^6.20.0
-    "@codemirror/commands": ^6.10.2
-    "@codemirror/lang-cpp": ^6.0.3
-    "@codemirror/lang-css": ^6.3.1
-    "@codemirror/lang-html": ^6.4.11
-    "@codemirror/lang-java": ^6.0.2
-    "@codemirror/lang-javascript": ^6.2.4
-    "@codemirror/lang-json": ^6.0.2
-    "@codemirror/lang-markdown": ^6.5.0
-    "@codemirror/lang-php": ^6.0.2
-    "@codemirror/lang-python": ^6.2.1
-    "@codemirror/lang-rust": ^6.0.2
-    "@codemirror/lang-sql": ^6.10.0
-    "@codemirror/lang-wast": ^6.0.2
-    "@codemirror/lang-xml": ^6.1.0
-    "@codemirror/language": ^6.12.1
-    "@codemirror/legacy-modes": ^6.5.2
-    "@codemirror/search": ^6.6.0
-    "@codemirror/state": ^6.5.4
-    "@codemirror/view": ^6.39.14
-    "@jupyter/ydoc": ^3.1.0
-    "@jupyterlab/codeeditor": ^4.5.5
-    "@jupyterlab/coreutils": ^6.5.5
-    "@jupyterlab/documentsearch": ^4.5.5
-    "@jupyterlab/nbformat": ^4.5.5
-    "@jupyterlab/translation": ^4.5.5
-    "@lezer/common": ^1.2.1
-    "@lezer/generator": ^1.7.0
-    "@lezer/highlight": ^1.2.0
-    "@lezer/markdown": ^1.3.0
-    "@lumino/coreutils": ^2.2.2
-    "@lumino/disposable": ^2.1.5
-    "@lumino/signaling": ^2.1.5
-    yjs: ^13.5.40
-  checksum: 055f85e57a8bf8960461723e79406e40ec3345730ff956f18542e8e9e8c2f08a166f8e809562c56524233ab7ee0b19b410da1c5fbe3ac557685f60179a6e6b3d
   languageName: node
   linkType: hard
 
@@ -1463,7 +1371,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/docmanager@npm:^4.2.0, @jupyterlab/docmanager@npm:^4.5.6":
+"@jupyterlab/docmanager@npm:^4.2.0, @jupyterlab/docmanager@npm:^4.5.5, @jupyterlab/docmanager@npm:^4.5.6":
   version: 4.5.6
   resolution: "@jupyterlab/docmanager@npm:4.5.6"
   dependencies:
@@ -1486,32 +1394,6 @@ __metadata:
     "@lumino/widgets": ^2.7.5
     react: ^18.2.0
   checksum: 6f0458b2bbebe3982d9d0bbea7775ac135e7e121772c8a40633303bc8ce98d5100895db044074b968f71a180ea327cad40193778057ed57f00c264c14d63b1ed
-  languageName: node
-  linkType: hard
-
-"@jupyterlab/docmanager@npm:^4.5.5":
-  version: 4.5.5
-  resolution: "@jupyterlab/docmanager@npm:4.5.5"
-  dependencies:
-    "@jupyterlab/apputils": ^4.6.5
-    "@jupyterlab/coreutils": ^6.5.5
-    "@jupyterlab/docregistry": ^4.5.5
-    "@jupyterlab/rendermime": ^4.5.5
-    "@jupyterlab/services": ^7.5.5
-    "@jupyterlab/statedb": ^4.5.5
-    "@jupyterlab/statusbar": ^4.5.5
-    "@jupyterlab/translation": ^4.5.5
-    "@jupyterlab/ui-components": ^4.5.5
-    "@lumino/algorithm": ^2.0.4
-    "@lumino/coreutils": ^2.2.2
-    "@lumino/disposable": ^2.1.5
-    "@lumino/messaging": ^2.0.4
-    "@lumino/polling": ^2.1.5
-    "@lumino/properties": ^2.0.4
-    "@lumino/signaling": ^2.1.5
-    "@lumino/widgets": ^2.7.5
-    react: ^18.2.0
-  checksum: 47d299243139e260f2abf744f9131cf9475fd415a63e4fc1f243d76d8e7e9a14501b3e2bcfaadfccea7ae2eb9fa8b1ccb049b9cca5a92b3687ce2b2b1ffeeaca
   languageName: node
   linkType: hard
 
@@ -1541,26 +1423,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/documentsearch@npm:^4.5.5":
-  version: 4.5.5
-  resolution: "@jupyterlab/documentsearch@npm:4.5.5"
-  dependencies:
-    "@jupyterlab/apputils": ^4.6.5
-    "@jupyterlab/translation": ^4.5.5
-    "@jupyterlab/ui-components": ^4.5.5
-    "@lumino/commands": ^2.3.3
-    "@lumino/coreutils": ^2.2.2
-    "@lumino/disposable": ^2.1.5
-    "@lumino/messaging": ^2.0.4
-    "@lumino/polling": ^2.1.5
-    "@lumino/signaling": ^2.1.5
-    "@lumino/widgets": ^2.7.5
-    react: ^18.2.0
-  checksum: 0b538fc1c26f786ee1e2064c7fbf205a90ab60b5773e0ac4df3173d3a0484b86333ba2e2be14b4a81de4805d18b86d5502f816a7dec2a14b36a7e5dd109b606d
-  languageName: node
-  linkType: hard
-
-"@jupyterlab/documentsearch@npm:^4.5.6":
+"@jupyterlab/documentsearch@npm:^4.5.5, @jupyterlab/documentsearch@npm:^4.5.6":
   version: 4.5.6
   resolution: "@jupyterlab/documentsearch@npm:4.5.6"
   dependencies:
@@ -1598,7 +1461,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/filebrowser@npm:^4.2.0, @jupyterlab/filebrowser@npm:^4.5.6":
+"@jupyterlab/filebrowser@npm:^4.2.0, @jupyterlab/filebrowser@npm:^4.5.5, @jupyterlab/filebrowser@npm:^4.5.6":
   version: 4.5.6
   resolution: "@jupyterlab/filebrowser@npm:4.5.6"
   dependencies:
@@ -1627,36 +1490,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/filebrowser@npm:^4.5.5":
-  version: 4.5.5
-  resolution: "@jupyterlab/filebrowser@npm:4.5.5"
-  dependencies:
-    "@jupyterlab/apputils": ^4.6.5
-    "@jupyterlab/coreutils": ^6.5.5
-    "@jupyterlab/docmanager": ^4.5.5
-    "@jupyterlab/docregistry": ^4.5.5
-    "@jupyterlab/services": ^7.5.5
-    "@jupyterlab/statedb": ^4.5.5
-    "@jupyterlab/statusbar": ^4.5.5
-    "@jupyterlab/translation": ^4.5.5
-    "@jupyterlab/ui-components": ^4.5.5
-    "@lumino/algorithm": ^2.0.4
-    "@lumino/coreutils": ^2.2.2
-    "@lumino/disposable": ^2.1.5
-    "@lumino/domutils": ^2.0.4
-    "@lumino/dragdrop": ^2.1.8
-    "@lumino/messaging": ^2.0.4
-    "@lumino/polling": ^2.1.5
-    "@lumino/signaling": ^2.1.5
-    "@lumino/virtualdom": ^2.0.4
-    "@lumino/widgets": ^2.7.5
-    jest-environment-jsdom: ^29.3.0
-    react: ^18.2.0
-  checksum: 1b480fc4fedbbce32bf81ee14cd832be65e2db51d2284f36172911872945340f169b8d4c3a21d2f5e048d13be7c5ef2e4c95102f34ab76d9bc56d58e8a49e765
-  languageName: node
-  linkType: hard
-
-"@jupyterlab/fileeditor@npm:^4.2.0":
+"@jupyterlab/fileeditor@npm:^4.2.0, @jupyterlab/fileeditor@npm:^4.5.5":
   version: 4.5.6
   resolution: "@jupyterlab/fileeditor@npm:4.5.6"
   dependencies:
@@ -1680,33 +1514,6 @@ __metadata:
     react: ^18.2.0
     regexp-match-indices: ^1.0.2
   checksum: 6735d2a6d47c5de27bf60fbb889dfffe1806fb25399dbdda16175cfffb011a9c25ac885aa9bbe8fbc72345f068beb3fc97da80223b09685f3c81ffb955541388
-  languageName: node
-  linkType: hard
-
-"@jupyterlab/fileeditor@npm:^4.5.5":
-  version: 4.5.5
-  resolution: "@jupyterlab/fileeditor@npm:4.5.5"
-  dependencies:
-    "@jupyter/ydoc": ^3.1.0
-    "@jupyterlab/apputils": ^4.6.5
-    "@jupyterlab/codeeditor": ^4.5.5
-    "@jupyterlab/codemirror": ^4.5.5
-    "@jupyterlab/coreutils": ^6.5.5
-    "@jupyterlab/docregistry": ^4.5.5
-    "@jupyterlab/documentsearch": ^4.5.5
-    "@jupyterlab/lsp": ^4.5.5
-    "@jupyterlab/rendermime": ^4.5.5
-    "@jupyterlab/statusbar": ^4.5.5
-    "@jupyterlab/toc": ^6.5.5
-    "@jupyterlab/translation": ^4.5.5
-    "@jupyterlab/ui-components": ^4.5.5
-    "@lumino/commands": ^2.3.3
-    "@lumino/coreutils": ^2.2.2
-    "@lumino/messaging": ^2.0.4
-    "@lumino/widgets": ^2.7.5
-    react: ^18.2.0
-    regexp-match-indices: ^1.0.2
-  checksum: 166f4778f1f0625f6990e23c7356d5e5ddbe2d374abf03ea5269d5150b5ef8b3e2d6fe51d6aa238bede4c1beeba6ff563b73f5d6e2eb3d2512c324c4807582dd
   languageName: node
   linkType: hard
 
@@ -1798,29 +1605,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/lsp@npm:^4.5.5":
-  version: 4.5.5
-  resolution: "@jupyterlab/lsp@npm:4.5.5"
-  dependencies:
-    "@jupyterlab/apputils": ^4.6.5
-    "@jupyterlab/codeeditor": ^4.5.5
-    "@jupyterlab/codemirror": ^4.5.5
-    "@jupyterlab/coreutils": ^6.5.5
-    "@jupyterlab/docregistry": ^4.5.5
-    "@jupyterlab/services": ^7.5.5
-    "@jupyterlab/translation": ^4.5.5
-    "@lumino/coreutils": ^2.2.2
-    "@lumino/disposable": ^2.1.5
-    "@lumino/signaling": ^2.1.5
-    "@lumino/widgets": ^2.7.5
-    lodash.mergewith: ^4.6.1
-    vscode-jsonrpc: ^6.0.0
-    vscode-languageserver-protocol: ^3.17.0
-    vscode-ws-jsonrpc: ~1.0.2
-  checksum: e17e1ab7359f6c1f2d81db4b9c70b5865df58f663a636026f18d0715b2170a1b9aab2fd8d6d690751767d9c6e78e98dcc74a6c7d2a51e346db2452ce9e27f575
-  languageName: node
-  linkType: hard
-
 "@jupyterlab/lsp@npm:^4.5.6":
   version: 4.5.6
   resolution: "@jupyterlab/lsp@npm:4.5.6"
@@ -1877,23 +1661,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/markedparser-extension@npm:^4.5.5":
-  version: 4.5.5
-  resolution: "@jupyterlab/markedparser-extension@npm:4.5.5"
-  dependencies:
-    "@jupyterlab/application": ^4.5.5
-    "@jupyterlab/codemirror": ^4.5.5
-    "@jupyterlab/coreutils": ^6.5.5
-    "@jupyterlab/mermaid": ^4.5.5
-    "@jupyterlab/rendermime": ^4.5.5
-    "@lumino/coreutils": ^2.2.2
-    marked: ^17.0.2
-    marked-gfm-heading-id: ^4.1.3
-    marked-mangle: ^1.1.12
-  checksum: 1ed86e3a1defa4a633e090303960be63838fcac0e9ee8855f98df9e3a17bfc5063c2d7b83498b4d3a15578139d52341f0f299d1a7753ea5f6e803c7a3bf7709a
-  languageName: node
-  linkType: hard
-
 "@jupyterlab/markedparser-extension@npm:^4.5.6":
   version: 4.5.6
   resolution: "@jupyterlab/markedparser-extension@npm:4.5.6"
@@ -1908,21 +1675,6 @@ __metadata:
     marked-gfm-heading-id: ^4.1.3
     marked-mangle: ^1.1.12
   checksum: 9f3b610497a18e34608f49f3dffade691c2b09c0ffbf44ab865dfe1f218571e4c99e9f518b811a97782c753986651525aa8cdfbfb40c4a286880736cffb7f74b
-  languageName: node
-  linkType: hard
-
-"@jupyterlab/mermaid@npm:^4.5.5":
-  version: 4.5.5
-  resolution: "@jupyterlab/mermaid@npm:4.5.5"
-  dependencies:
-    "@jupyterlab/apputils": ^4.6.5
-    "@jupyterlab/coreutils": ^6.5.5
-    "@jupyterlab/rendermime-interfaces": ^3.13.5
-    "@lumino/coreutils": ^2.2.2
-    "@lumino/widgets": ^2.7.5
-    "@mermaid-js/layout-elk": ^0.2.0
-    mermaid: ^11.12.3
-  checksum: 3094bac75b42ddc72ea8a0fa08887464d347cd2d54bc632ede05cbd30ce1c744a92e40ac50fe9a129ae57eb069569683f3e2b3c6c0bd4aa8c6936adeb9826a56
   languageName: node
   linkType: hard
 
@@ -1986,7 +1738,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/notebook@npm:^4.2.0":
+"@jupyterlab/notebook@npm:^4.2.0, @jupyterlab/notebook@npm:^4.5.0, @jupyterlab/notebook@npm:^4.5.5":
   version: 4.5.6
   resolution: "@jupyterlab/notebook@npm:4.5.6"
   dependencies:
@@ -2025,45 +1777,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/notebook@npm:^4.5.0, @jupyterlab/notebook@npm:^4.5.5":
-  version: 4.5.5
-  resolution: "@jupyterlab/notebook@npm:4.5.5"
-  dependencies:
-    "@jupyter/ydoc": ^3.1.0
-    "@jupyterlab/apputils": ^4.6.5
-    "@jupyterlab/cells": ^4.5.5
-    "@jupyterlab/codeeditor": ^4.5.5
-    "@jupyterlab/codemirror": ^4.5.5
-    "@jupyterlab/coreutils": ^6.5.5
-    "@jupyterlab/docregistry": ^4.5.5
-    "@jupyterlab/documentsearch": ^4.5.5
-    "@jupyterlab/lsp": ^4.5.5
-    "@jupyterlab/markedparser-extension": ^4.5.5
-    "@jupyterlab/nbformat": ^4.5.5
-    "@jupyterlab/observables": ^5.5.5
-    "@jupyterlab/rendermime": ^4.5.5
-    "@jupyterlab/services": ^7.5.5
-    "@jupyterlab/settingregistry": ^4.5.5
-    "@jupyterlab/statusbar": ^4.5.5
-    "@jupyterlab/toc": ^6.5.5
-    "@jupyterlab/translation": ^4.5.5
-    "@jupyterlab/ui-components": ^4.5.5
-    "@lumino/algorithm": ^2.0.4
-    "@lumino/coreutils": ^2.2.2
-    "@lumino/disposable": ^2.1.5
-    "@lumino/domutils": ^2.0.4
-    "@lumino/dragdrop": ^2.1.8
-    "@lumino/messaging": ^2.0.4
-    "@lumino/polling": ^2.1.5
-    "@lumino/properties": ^2.0.4
-    "@lumino/signaling": ^2.1.5
-    "@lumino/virtualdom": ^2.0.4
-    "@lumino/widgets": ^2.7.5
-    react: ^18.2.0
-  checksum: 997d2bb819f602ebc36ec2c4fe63a613e33886a98045514db0a35ac8f032a0632d354cfed03f779389a4a2ff859b1b44ba88aa6ef109dc60f62b4e7409fc636d
-  languageName: node
-  linkType: hard
-
 "@jupyterlab/observables@npm:^5.5.5, @jupyterlab/observables@npm:^5.5.6":
   version: 5.5.6
   resolution: "@jupyterlab/observables@npm:5.5.6"
@@ -2077,29 +1790,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/outputarea@npm:^4.5.5":
-  version: 4.5.5
-  resolution: "@jupyterlab/outputarea@npm:4.5.5"
-  dependencies:
-    "@jupyterlab/apputils": ^4.6.5
-    "@jupyterlab/nbformat": ^4.5.5
-    "@jupyterlab/observables": ^5.5.5
-    "@jupyterlab/rendermime": ^4.5.5
-    "@jupyterlab/rendermime-interfaces": ^3.13.5
-    "@jupyterlab/services": ^7.5.5
-    "@jupyterlab/translation": ^4.5.5
-    "@lumino/algorithm": ^2.0.4
-    "@lumino/coreutils": ^2.2.2
-    "@lumino/disposable": ^2.1.5
-    "@lumino/messaging": ^2.0.4
-    "@lumino/properties": ^2.0.4
-    "@lumino/signaling": ^2.1.5
-    "@lumino/widgets": ^2.7.5
-  checksum: b456616a23efa0701c8cb123f8d1e9ce3d0a1ef4ee1604f7494728f5ed2edd81caf8a702bcc26d94c71224c64f37bfc7cc78961343b02607193b84821039bae2
-  languageName: node
-  linkType: hard
-
-"@jupyterlab/outputarea@npm:^4.5.6":
+"@jupyterlab/outputarea@npm:^4.5.5, @jupyterlab/outputarea@npm:^4.5.6":
   version: 4.5.6
   resolution: "@jupyterlab/outputarea@npm:4.5.6"
   dependencies:
@@ -2221,7 +1912,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/rendermime-interfaces@npm:^3.13.5, @jupyterlab/rendermime-interfaces@npm:^3.13.6, @jupyterlab/rendermime-interfaces@npm:~3.13.6":
+"@jupyterlab/rendermime-interfaces@npm:^3.13.6, @jupyterlab/rendermime-interfaces@npm:~3.13.6":
   version: 3.13.6
   resolution: "@jupyterlab/rendermime-interfaces@npm:3.13.6"
   dependencies:
@@ -2352,7 +2043,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/statusbar@npm:^4.5.5, @jupyterlab/statusbar@npm:^4.5.6":
+"@jupyterlab/statusbar@npm:^4.5.6":
   version: 4.5.6
   resolution: "@jupyterlab/statusbar@npm:4.5.6"
   dependencies:
@@ -2391,30 +2082,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/toc@npm:^6.5.5":
-  version: 6.5.5
-  resolution: "@jupyterlab/toc@npm:6.5.5"
-  dependencies:
-    "@jupyter/react-components": ^0.16.6
-    "@jupyterlab/apputils": ^4.6.5
-    "@jupyterlab/coreutils": ^6.5.5
-    "@jupyterlab/docregistry": ^4.5.5
-    "@jupyterlab/observables": ^5.5.5
-    "@jupyterlab/rendermime": ^4.5.5
-    "@jupyterlab/rendermime-interfaces": ^3.13.5
-    "@jupyterlab/translation": ^4.5.5
-    "@jupyterlab/ui-components": ^4.5.5
-    "@lumino/coreutils": ^2.2.2
-    "@lumino/disposable": ^2.1.5
-    "@lumino/messaging": ^2.0.4
-    "@lumino/signaling": ^2.1.5
-    "@lumino/widgets": ^2.7.5
-    react: ^18.2.0
-  checksum: 28597bbf1d921443c6c6099c109fda122ac64896264513b5d91ff2d9b685e7ec0ca4b6bd947e1c5ed6fdfe65aef0099f9fe2a9bb38f9c907228bcca6d5d6f1f9
-  languageName: node
-  linkType: hard
-
-"@jupyterlab/toc@npm:^6.5.6":
+"@jupyterlab/toc@npm:^6.5.5, @jupyterlab/toc@npm:^6.5.6":
   version: 6.5.6
   resolution: "@jupyterlab/toc@npm:6.5.6"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,7 +15,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.12.13":
+"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.28.6, @babel/code-frame@npm:^7.29.0":
   version: 7.29.0
   resolution: "@babel/code-frame@npm:7.29.0"
   dependencies:
@@ -26,10 +26,101 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:^7.29.0":
+  version: 7.29.1
+  resolution: "@babel/generator@npm:7.29.1"
+  dependencies:
+    "@babel/parser": ^7.29.0
+    "@babel/types": ^7.29.0
+    "@jridgewell/gen-mapping": ^0.3.12
+    "@jridgewell/trace-mapping": ^0.3.28
+    jsesc: ^3.0.2
+  checksum: d8e6863b2d04f684e65ad72731049ac7d754d3a3d1a67cdfc20807b109ba3180ed90d7ccef58ce5d38ded2eaeb71983a76c711eecb9b6266118262378f6c7226
+  languageName: node
+  linkType: hard
+
+"@babel/helper-globals@npm:^7.28.0":
+  version: 7.28.0
+  resolution: "@babel/helper-globals@npm:7.28.0"
+  checksum: d8d7b91c12dad1ee747968af0cb73baf91053b2bcf78634da2c2c4991fb45ede9bd0c8f9b5f3254881242bc0921218fcb7c28ae885477c25177147e978ce4397
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-imports@npm:^7.16.7":
+  version: 7.28.6
+  resolution: "@babel/helper-module-imports@npm:7.28.6"
+  dependencies:
+    "@babel/traverse": ^7.28.6
+    "@babel/types": ^7.28.6
+  checksum: 437513aa029898b588a38f7991d7656c539b22f595207d85d0c407240c9e3f2aff8b9d0d7115fdedc91e7fdce4465100549a052024e2fba6a810bcbb7584296b
+  languageName: node
+  linkType: hard
+
+"@babel/helper-string-parser@npm:^7.27.1":
+  version: 7.27.1
+  resolution: "@babel/helper-string-parser@npm:7.27.1"
+  checksum: 0a8464adc4b39b138aedcb443b09f4005d86207d7126e5e079177e05c3116107d856ec08282b365e9a79a9872f40f4092a6127f8d74c8a01c1ef789dacfc25d6
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.28.5":
   version: 7.28.5
   resolution: "@babel/helper-validator-identifier@npm:7.28.5"
   checksum: 5a251a6848e9712aea0338f659a1a3bd334d26219d5511164544ca8ec20774f098c3a6661e9da65a0d085c745c00bb62c8fada38a62f08fa1f8053bc0aeb57e4
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.28.6, @babel/parser@npm:^7.29.0":
+  version: 7.29.2
+  resolution: "@babel/parser@npm:7.29.2"
+  dependencies:
+    "@babel/types": ^7.29.0
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 25249623ffceb61beda0ba67776cf3957ffd49bef3005ccb81da3049db52115c91ad97c97da661b714f92d062e052d07bd2ba6cba6b5460f168ff38dabaf4d6d
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.28.6, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.7":
+  version: 7.29.2
+  resolution: "@babel/runtime@npm:7.29.2"
+  checksum: d5548d1165de8995f8afc93a5694b8625409be16cd1f2250ac13e331335858ddac3cb9fd278e6c43956a130101a2203f09417938a1a96f9fb70f02b4b4172e1d
+  languageName: node
+  linkType: hard
+
+"@babel/template@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/template@npm:7.28.6"
+  dependencies:
+    "@babel/code-frame": ^7.28.6
+    "@babel/parser": ^7.28.6
+    "@babel/types": ^7.28.6
+  checksum: 8ab6383053e226025d9491a6e795293f2140482d14f60c1244bece6bf53610ed1e251d5e164de66adab765629881c7d9416e1e540c716541d2fd0f8f36a013d7
+  languageName: node
+  linkType: hard
+
+"@babel/traverse@npm:^7.28.6":
+  version: 7.29.0
+  resolution: "@babel/traverse@npm:7.29.0"
+  dependencies:
+    "@babel/code-frame": ^7.29.0
+    "@babel/generator": ^7.29.0
+    "@babel/helper-globals": ^7.28.0
+    "@babel/parser": ^7.29.0
+    "@babel/template": ^7.28.6
+    "@babel/types": ^7.29.0
+    debug: ^4.3.1
+  checksum: fbb5085aa525b5d4ecd9fe2f5885d88413fff6ad9c0fac244c37f96069b6d3af9ce825750cd16af1d97d26fa3d354b38dbbdb5f31430e0d99ed89660ab65430e
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.28.6, @babel/types@npm:^7.29.0":
+  version: 7.29.0
+  resolution: "@babel/types@npm:7.29.0"
+  dependencies:
+    "@babel/helper-string-parser": ^7.27.1
+    "@babel/helper-validator-identifier": ^7.28.5
+  checksum: 83f190438e94c22b2574aaeef7501830311ef266eaabfb06523409f64e2fe855e522951607085d71cad286719adef14e1ba37b671f334a7cd25b0f8506a01e0b
   languageName: node
   linkType: hard
 
@@ -345,6 +436,152 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emotion/babel-plugin@npm:^11.13.5":
+  version: 11.13.5
+  resolution: "@emotion/babel-plugin@npm:11.13.5"
+  dependencies:
+    "@babel/helper-module-imports": ^7.16.7
+    "@babel/runtime": ^7.18.3
+    "@emotion/hash": ^0.9.2
+    "@emotion/memoize": ^0.9.0
+    "@emotion/serialize": ^1.3.3
+    babel-plugin-macros: ^3.1.0
+    convert-source-map: ^1.5.0
+    escape-string-regexp: ^4.0.0
+    find-root: ^1.1.0
+    source-map: ^0.5.7
+    stylis: 4.2.0
+  checksum: c41df7e6c19520e76d1939f884be878bf88b5ba00bd3de9d05c5b6c5baa5051686ab124d7317a0645de1b017b574d8139ae1d6390ec267fbe8e85a5252afb542
+  languageName: node
+  linkType: hard
+
+"@emotion/cache@npm:^11.14.0":
+  version: 11.14.0
+  resolution: "@emotion/cache@npm:11.14.0"
+  dependencies:
+    "@emotion/memoize": ^0.9.0
+    "@emotion/sheet": ^1.4.0
+    "@emotion/utils": ^1.4.2
+    "@emotion/weak-memoize": ^0.4.0
+    stylis: 4.2.0
+  checksum: 0a81591541ea43bc7851742e6444b7800d72e98006f94e775ae6ea0806662d14e0a86ff940f5f19d33b4bb2c427c882aa65d417e7322a6e0d5f20fe65ed920c9
+  languageName: node
+  linkType: hard
+
+"@emotion/hash@npm:^0.9.2":
+  version: 0.9.2
+  resolution: "@emotion/hash@npm:0.9.2"
+  checksum: 379bde2830ccb0328c2617ec009642321c0e009a46aa383dfbe75b679c6aea977ca698c832d225a893901f29d7b3eef0e38cf341f560f6b2b56f1ff23c172387
+  languageName: node
+  linkType: hard
+
+"@emotion/is-prop-valid@npm:^1.3.0":
+  version: 1.4.0
+  resolution: "@emotion/is-prop-valid@npm:1.4.0"
+  dependencies:
+    "@emotion/memoize": ^0.9.0
+  checksum: 6b003cdc62106c2d5d12207c2d1352d674339252a2d7ac8d96974781d7c639833f35d22e7e331411795daaafa62f126c2824a4983584292b431e08b42877d51e
+  languageName: node
+  linkType: hard
+
+"@emotion/memoize@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "@emotion/memoize@npm:0.9.0"
+  checksum: 038132359397348e378c593a773b1148cd0cf0a2285ffd067a0f63447b945f5278860d9de718f906a74c7c940ba1783ac2ca18f1c06a307b01cc0e3944e783b1
+  languageName: node
+  linkType: hard
+
+"@emotion/react@npm:^11.10.5":
+  version: 11.14.0
+  resolution: "@emotion/react@npm:11.14.0"
+  dependencies:
+    "@babel/runtime": ^7.18.3
+    "@emotion/babel-plugin": ^11.13.5
+    "@emotion/cache": ^11.14.0
+    "@emotion/serialize": ^1.3.3
+    "@emotion/use-insertion-effect-with-fallbacks": ^1.2.0
+    "@emotion/utils": ^1.4.2
+    "@emotion/weak-memoize": ^0.4.0
+    hoist-non-react-statics: ^3.3.1
+  peerDependencies:
+    react: ">=16.8.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 3cf023b11d132b56168713764d6fced8e5a1f0687dfe0caa2782dfd428c8f9e30f9826a919965a311d87b523cd196722aaf75919cd0f6bd0fd57f8a6a0281500
+  languageName: node
+  linkType: hard
+
+"@emotion/serialize@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "@emotion/serialize@npm:1.3.3"
+  dependencies:
+    "@emotion/hash": ^0.9.2
+    "@emotion/memoize": ^0.9.0
+    "@emotion/unitless": ^0.10.0
+    "@emotion/utils": ^1.4.2
+    csstype: ^3.0.2
+  checksum: 510331233767ae4e09e925287ca2c7269b320fa1d737ea86db5b3c861a734483ea832394c0c1fe5b21468fe335624a75e72818831d303ba38125f54f44ba02e7
+  languageName: node
+  linkType: hard
+
+"@emotion/sheet@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "@emotion/sheet@npm:1.4.0"
+  checksum: eeb1212e3289db8e083e72e7e401cd6d1a84deece87e9ce184f7b96b9b5dbd6f070a89057255a6ff14d9865c3ce31f27c39248a053e4cdd875540359042586b4
+  languageName: node
+  linkType: hard
+
+"@emotion/styled@npm:^11.10.5":
+  version: 11.14.1
+  resolution: "@emotion/styled@npm:11.14.1"
+  dependencies:
+    "@babel/runtime": ^7.18.3
+    "@emotion/babel-plugin": ^11.13.5
+    "@emotion/is-prop-valid": ^1.3.0
+    "@emotion/serialize": ^1.3.3
+    "@emotion/use-insertion-effect-with-fallbacks": ^1.2.0
+    "@emotion/utils": ^1.4.2
+  peerDependencies:
+    "@emotion/react": ^11.0.0-rc.0
+    react: ">=16.8.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 86238d9f5c41232a73499e441fa9112e855545519d6772f489fa885634bb8f31b422a9ba9d1e8bc0b4ad66132f9d398b1c309d92c19c5ee21356b41671ec984a
+  languageName: node
+  linkType: hard
+
+"@emotion/unitless@npm:^0.10.0":
+  version: 0.10.0
+  resolution: "@emotion/unitless@npm:0.10.0"
+  checksum: d79346df31a933e6d33518e92636afeb603ce043f3857d0a39a2ac78a09ef0be8bedff40130930cb25df1beeee12d96ee38613963886fa377c681a89970b787c
+  languageName: node
+  linkType: hard
+
+"@emotion/use-insertion-effect-with-fallbacks@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@emotion/use-insertion-effect-with-fallbacks@npm:1.2.0"
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 8ff6aec7f2924526ff8c8f8f93d4b8236376e2e12c435314a18c9a373016e24dfdf984e82bbc83712b8e90ff4783cd765eb39fc7050d1a43245e5728740ddd71
+  languageName: node
+  linkType: hard
+
+"@emotion/utils@npm:^1.4.2":
+  version: 1.4.2
+  resolution: "@emotion/utils@npm:1.4.2"
+  checksum: 04cf76849c6401205c058b82689fd0ec5bf501aed6974880fe9681a1d61543efb97e848f4c38664ac4a9068c7ad2d1cb84f73bde6cf95f1208aa3c28e0190321
+  languageName: node
+  linkType: hard
+
+"@emotion/weak-memoize@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@emotion/weak-memoize@npm:0.4.0"
+  checksum: db5da0e89bd752c78b6bd65a1e56231f0abebe2f71c0bd8fc47dff96408f7065b02e214080f99924f6a3bfe7ee15afc48dad999d76df86b39b16e513f7a94f52
+  languageName: node
+  linkType: hard
+
 "@eslint-community/eslint-utils@npm:^4.8.0, @eslint-community/eslint-utils@npm:^4.9.1":
   version: 4.9.1
   resolution: "@eslint-community/eslint-utils@npm:4.9.1"
@@ -556,7 +793,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/gen-mapping@npm:^0.3.5":
+"@jridgewell/gen-mapping@npm:^0.3.12, @jridgewell/gen-mapping@npm:^0.3.5":
   version: 0.3.13
   resolution: "@jridgewell/gen-mapping@npm:0.3.13"
   dependencies:
@@ -590,7 +827,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.25":
+"@jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.25, @jridgewell/trace-mapping@npm:^0.3.28":
   version: 0.3.31
   resolution: "@jridgewell/trace-mapping@npm:0.3.31"
   dependencies:
@@ -633,6 +870,41 @@ __metadata:
     jquery: ^3.1.1
     lodash: ^4.17.4
   checksum: 7ec558edd5519e76a4e1a6d5209927b34f19d4e4a3b76a4dba89f67784dd50fef8b536cd15694576fa1930e3c92822c7565ddb47d1b558444c596af24b78790b
+  languageName: node
+  linkType: hard
+
+"@jupyter/chat@npm:^0.21.0":
+  version: 0.21.0
+  resolution: "@jupyter/chat@npm:0.21.0"
+  dependencies:
+    "@emotion/react": ^11.10.5
+    "@emotion/styled": ^11.10.5
+    "@jupyter/react-components": ^0.15.2
+    "@jupyterlab/application": ^4.2.0
+    "@jupyterlab/apputils": ^4.3.0
+    "@jupyterlab/codeeditor": ^4.2.0
+    "@jupyterlab/codemirror": ^4.2.0
+    "@jupyterlab/docmanager": ^4.2.0
+    "@jupyterlab/docregistry": ^4.2.0
+    "@jupyterlab/filebrowser": ^4.2.0
+    "@jupyterlab/fileeditor": ^4.2.0
+    "@jupyterlab/notebook": ^4.2.0
+    "@jupyterlab/rendermime": ^4.2.0
+    "@jupyterlab/translation": ^4.2.0
+    "@jupyterlab/ui-components": ^4.2.0
+    "@lumino/algorithm": ^2.0.0
+    "@lumino/commands": ^2.0.0
+    "@lumino/coreutils": ^2.0.0
+    "@lumino/disposable": ^2.0.0
+    "@lumino/polling": ^2.0.0
+    "@lumino/signaling": ^2.0.0
+    "@lumino/widgets": ^2.0.0
+    "@mui/icons-material": ^7.3.2
+    "@mui/material": ^7.3.2
+    clsx: ^2.1.0
+    react: ^18.2.0
+    react-dom: ^18.2.0
+  checksum: 34f75c62d9006b92607a46db00d491610796c73e091a65a479d188b113e935c295a6d9f56e23ffdeb3db58e8afc9d33c1eaff3ae14a10410191cd9b2b1b3e025
   languageName: node
   linkType: hard
 
@@ -680,6 +952,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyter/react-components@npm:^0.15.2":
+  version: 0.15.3
+  resolution: "@jupyter/react-components@npm:0.15.3"
+  dependencies:
+    "@jupyter/web-components": ^0.15.3
+    "@microsoft/fast-react-wrapper": ^0.3.22
+    react: ">=17.0.0 <19.0.0"
+  checksum: 1a6b256314259c6465c4b6d958575710536b82234a7bf0fba3e889a07e1f19ff8ab321450be354359876f92c45dbcc9d21a840237ff4a619806d9de696f55496
+  languageName: node
+  linkType: hard
+
 "@jupyter/react-components@npm:^0.16.6":
   version: 0.16.7
   resolution: "@jupyter/react-components@npm:0.16.7"
@@ -687,6 +970,18 @@ __metadata:
     "@jupyter/web-components": ^0.16.7
     react: ">=17.0.0 <19.0.0"
   checksum: 37894347e63ebb528725e8b8b4038d138019823f5c9e28e3f6abb93b46d771b2ee3cc004d5ff7d9a06a93f2d90e41000bd2abae14364be34ba99c5e05864810e
+  languageName: node
+  linkType: hard
+
+"@jupyter/web-components@npm:^0.15.3":
+  version: 0.15.3
+  resolution: "@jupyter/web-components@npm:0.15.3"
+  dependencies:
+    "@microsoft/fast-colors": ^5.3.1
+    "@microsoft/fast-element": ^1.12.0
+    "@microsoft/fast-foundation": ^2.49.4
+    "@microsoft/fast-web-utilities": ^5.4.1
+  checksum: a0980af934157bfdbdb6cc169c0816c1b2e57602d524c56bdcef746a4c25dfeb8f505150d83207c8695ed89b5486cf53d35a3382584d25ef64db666e4e16e45b
   languageName: node
   linkType: hard
 
@@ -716,7 +1011,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/application@npm:^4.5.5, @jupyterlab/application@npm:~4.5.6":
+"@jupyterlab/application@npm:^4.2.0, @jupyterlab/application@npm:^4.5.5, @jupyterlab/application@npm:^4.5.6, @jupyterlab/application@npm:~4.5.6":
   version: 4.5.6
   resolution: "@jupyterlab/application@npm:4.5.6"
   dependencies:
@@ -744,7 +1039,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/apputils@npm:^4.5.0, @jupyterlab/apputils@npm:^4.6.5, @jupyterlab/apputils@npm:^4.6.6":
+"@jupyterlab/apputils@npm:^4.3.0, @jupyterlab/apputils@npm:^4.5.0, @jupyterlab/apputils@npm:^4.6.5, @jupyterlab/apputils@npm:^4.6.6":
   version: 4.6.6
   resolution: "@jupyterlab/apputils@npm:4.6.6"
   dependencies:
@@ -784,6 +1079,20 @@ __metadata:
     "@lumino/disposable": ^2.1.5
     "@lumino/signaling": ^2.1.5
   checksum: 2ace675bc222ab11c3c1967efdfb9f1f87d1e50da3beb9428f62a4e78e40278249f2b56bf04c9118e4736df88233c1fd351a43826cd5be74d62498fe03de740f
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/attachments@npm:^4.5.6":
+  version: 4.5.6
+  resolution: "@jupyterlab/attachments@npm:4.5.6"
+  dependencies:
+    "@jupyterlab/nbformat": ^4.5.6
+    "@jupyterlab/observables": ^5.5.6
+    "@jupyterlab/rendermime": ^4.5.6
+    "@jupyterlab/rendermime-interfaces": ^3.13.6
+    "@lumino/disposable": ^2.1.5
+    "@lumino/signaling": ^2.1.5
+  checksum: 80318fb705467a0e9547c3918f046d701e0be493d1e39e35ce71bee365f924cb85e2e4ddf0c8087a0e42222efed7abdb578a5e5e17e46409d6ebb71df280b514
   languageName: node
   linkType: hard
 
@@ -885,7 +1194,43 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/codeeditor@npm:^4.5.5, @jupyterlab/codeeditor@npm:^4.5.6":
+"@jupyterlab/cells@npm:^4.5.6":
+  version: 4.5.6
+  resolution: "@jupyterlab/cells@npm:4.5.6"
+  dependencies:
+    "@codemirror/state": ^6.5.4
+    "@codemirror/view": ^6.39.14
+    "@jupyter/ydoc": ^3.1.0
+    "@jupyterlab/apputils": ^4.6.6
+    "@jupyterlab/attachments": ^4.5.6
+    "@jupyterlab/codeeditor": ^4.5.6
+    "@jupyterlab/codemirror": ^4.5.6
+    "@jupyterlab/coreutils": ^6.5.6
+    "@jupyterlab/documentsearch": ^4.5.6
+    "@jupyterlab/filebrowser": ^4.5.6
+    "@jupyterlab/nbformat": ^4.5.6
+    "@jupyterlab/observables": ^5.5.6
+    "@jupyterlab/outputarea": ^4.5.6
+    "@jupyterlab/rendermime": ^4.5.6
+    "@jupyterlab/services": ^7.5.6
+    "@jupyterlab/toc": ^6.5.6
+    "@jupyterlab/translation": ^4.5.6
+    "@jupyterlab/ui-components": ^4.5.6
+    "@lumino/algorithm": ^2.0.4
+    "@lumino/coreutils": ^2.2.2
+    "@lumino/domutils": ^2.0.4
+    "@lumino/dragdrop": ^2.1.8
+    "@lumino/messaging": ^2.0.4
+    "@lumino/polling": ^2.1.5
+    "@lumino/signaling": ^2.1.5
+    "@lumino/virtualdom": ^2.0.4
+    "@lumino/widgets": ^2.7.5
+    react: ^18.2.0
+  checksum: 587b0e4e897663da642dcf63c1d9d7f5d7eb69dc47427d120c76bfd6eb80c4c1d2bbf8bf7f67484170f253a0c099613b2c349b2e962c50233cf651b463f536cd
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/codeeditor@npm:^4.2.0, @jupyterlab/codeeditor@npm:^4.5.5, @jupyterlab/codeeditor@npm:^4.5.6":
   version: 4.5.6
   resolution: "@jupyterlab/codeeditor@npm:4.5.6"
   dependencies:
@@ -906,6 +1251,48 @@ __metadata:
     "@lumino/widgets": ^2.7.5
     react: ^18.2.0
   checksum: 298cab335372ba900dcf1f811f31272f2fb214b42411eca44b39c66c1910b865a223015642b3f8ddc0a24e1a5eba7b424f771ded735f74e602d21491ad3c945f
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/codemirror@npm:^4.2.0, @jupyterlab/codemirror@npm:^4.5.6":
+  version: 4.5.6
+  resolution: "@jupyterlab/codemirror@npm:4.5.6"
+  dependencies:
+    "@codemirror/autocomplete": ^6.20.0
+    "@codemirror/commands": ^6.10.2
+    "@codemirror/lang-cpp": ^6.0.3
+    "@codemirror/lang-css": ^6.3.1
+    "@codemirror/lang-html": ^6.4.11
+    "@codemirror/lang-java": ^6.0.2
+    "@codemirror/lang-javascript": ^6.2.4
+    "@codemirror/lang-json": ^6.0.2
+    "@codemirror/lang-markdown": ^6.5.0
+    "@codemirror/lang-php": ^6.0.2
+    "@codemirror/lang-python": ^6.2.1
+    "@codemirror/lang-rust": ^6.0.2
+    "@codemirror/lang-sql": ^6.10.0
+    "@codemirror/lang-wast": ^6.0.2
+    "@codemirror/lang-xml": ^6.1.0
+    "@codemirror/language": ^6.12.1
+    "@codemirror/legacy-modes": ^6.5.2
+    "@codemirror/search": ^6.6.0
+    "@codemirror/state": ^6.5.4
+    "@codemirror/view": ^6.39.14
+    "@jupyter/ydoc": ^3.1.0
+    "@jupyterlab/codeeditor": ^4.5.6
+    "@jupyterlab/coreutils": ^6.5.6
+    "@jupyterlab/documentsearch": ^4.5.6
+    "@jupyterlab/nbformat": ^4.5.6
+    "@jupyterlab/translation": ^4.5.6
+    "@lezer/common": ^1.2.1
+    "@lezer/generator": ^1.7.0
+    "@lezer/highlight": ^1.2.0
+    "@lezer/markdown": ^1.3.0
+    "@lumino/coreutils": ^2.2.2
+    "@lumino/disposable": ^2.1.5
+    "@lumino/signaling": ^2.1.5
+    yjs: ^13.5.40
+  checksum: 41ac99b7fc675875c7eece4b24f779cd7e26b525cb9646c7ffbeeb70c0c5d6e1221175d12dc62f3b0dcbdb9ee5cef9dbc60b4227f2a950c62502249e4dca7f40
   languageName: node
   linkType: hard
 
@@ -1076,6 +1463,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/docmanager@npm:^4.2.0, @jupyterlab/docmanager@npm:^4.5.6":
+  version: 4.5.6
+  resolution: "@jupyterlab/docmanager@npm:4.5.6"
+  dependencies:
+    "@jupyterlab/apputils": ^4.6.6
+    "@jupyterlab/coreutils": ^6.5.6
+    "@jupyterlab/docregistry": ^4.5.6
+    "@jupyterlab/rendermime": ^4.5.6
+    "@jupyterlab/services": ^7.5.6
+    "@jupyterlab/statedb": ^4.5.6
+    "@jupyterlab/statusbar": ^4.5.6
+    "@jupyterlab/translation": ^4.5.6
+    "@jupyterlab/ui-components": ^4.5.6
+    "@lumino/algorithm": ^2.0.4
+    "@lumino/coreutils": ^2.2.2
+    "@lumino/disposable": ^2.1.5
+    "@lumino/messaging": ^2.0.4
+    "@lumino/polling": ^2.1.5
+    "@lumino/properties": ^2.0.4
+    "@lumino/signaling": ^2.1.5
+    "@lumino/widgets": ^2.7.5
+    react: ^18.2.0
+  checksum: 6f0458b2bbebe3982d9d0bbea7775ac135e7e121772c8a40633303bc8ce98d5100895db044074b968f71a180ea327cad40193778057ed57f00c264c14d63b1ed
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/docmanager@npm:^4.5.5":
   version: 4.5.5
   resolution: "@jupyterlab/docmanager@npm:4.5.5"
@@ -1102,7 +1515,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/docregistry@npm:^4.5.5, @jupyterlab/docregistry@npm:^4.5.6, @jupyterlab/docregistry@npm:~4.5.6":
+"@jupyterlab/docregistry@npm:^4.2.0, @jupyterlab/docregistry@npm:^4.5.5, @jupyterlab/docregistry@npm:^4.5.6, @jupyterlab/docregistry@npm:~4.5.6":
   version: 4.5.6
   resolution: "@jupyterlab/docregistry@npm:4.5.6"
   dependencies:
@@ -1147,6 +1560,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/documentsearch@npm:^4.5.6":
+  version: 4.5.6
+  resolution: "@jupyterlab/documentsearch@npm:4.5.6"
+  dependencies:
+    "@jupyterlab/apputils": ^4.6.6
+    "@jupyterlab/translation": ^4.5.6
+    "@jupyterlab/ui-components": ^4.5.6
+    "@lumino/commands": ^2.3.3
+    "@lumino/coreutils": ^2.2.2
+    "@lumino/disposable": ^2.1.5
+    "@lumino/messaging": ^2.0.4
+    "@lumino/polling": ^2.1.5
+    "@lumino/signaling": ^2.1.5
+    "@lumino/widgets": ^2.7.5
+    react: ^18.2.0
+  checksum: d76bebc8d2ee7b76e476b145aff773e637e8c11d5d40bf9035b5dd8bd00fc712a3347327ff2eff0387095e12777eb53a6416502e2c17517027a42c8e0592261a
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/extensionmanager@npm:^4.5.5":
   version: 4.5.5
   resolution: "@jupyterlab/extensionmanager@npm:4.5.5"
@@ -1163,6 +1595,35 @@ __metadata:
     react-paginate: ^6.3.2
     semver: ^7.5.2
   checksum: 9a82a4bfcdd9cbe5469d244e84785d7a183a451f25cd76ba6a5c1a16b375d6728b7bf3f149e5ad4a86fe5a10ef966fca224dab3ca784ef28be9beb7cb80640d0
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/filebrowser@npm:^4.2.0, @jupyterlab/filebrowser@npm:^4.5.6":
+  version: 4.5.6
+  resolution: "@jupyterlab/filebrowser@npm:4.5.6"
+  dependencies:
+    "@jupyterlab/apputils": ^4.6.6
+    "@jupyterlab/coreutils": ^6.5.6
+    "@jupyterlab/docmanager": ^4.5.6
+    "@jupyterlab/docregistry": ^4.5.6
+    "@jupyterlab/services": ^7.5.6
+    "@jupyterlab/statedb": ^4.5.6
+    "@jupyterlab/statusbar": ^4.5.6
+    "@jupyterlab/translation": ^4.5.6
+    "@jupyterlab/ui-components": ^4.5.6
+    "@lumino/algorithm": ^2.0.4
+    "@lumino/coreutils": ^2.2.2
+    "@lumino/disposable": ^2.1.5
+    "@lumino/domutils": ^2.0.4
+    "@lumino/dragdrop": ^2.1.8
+    "@lumino/messaging": ^2.0.4
+    "@lumino/polling": ^2.1.5
+    "@lumino/signaling": ^2.1.5
+    "@lumino/virtualdom": ^2.0.4
+    "@lumino/widgets": ^2.7.5
+    jest-environment-jsdom: ^29.3.0
+    react: ^18.2.0
+  checksum: d8fb64ccfa2ffb19d16ce041efdca8877838f6f5738f99411c67cc235465fbfd82bdc1f156bba0a93266d4c581ceb5e1212e6ec1413799522acad19231a474e7
   languageName: node
   linkType: hard
 
@@ -1192,6 +1653,33 @@ __metadata:
     jest-environment-jsdom: ^29.3.0
     react: ^18.2.0
   checksum: 1b480fc4fedbbce32bf81ee14cd832be65e2db51d2284f36172911872945340f169b8d4c3a21d2f5e048d13be7c5ef2e4c95102f34ab76d9bc56d58e8a49e765
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/fileeditor@npm:^4.2.0":
+  version: 4.5.6
+  resolution: "@jupyterlab/fileeditor@npm:4.5.6"
+  dependencies:
+    "@jupyter/ydoc": ^3.1.0
+    "@jupyterlab/apputils": ^4.6.6
+    "@jupyterlab/codeeditor": ^4.5.6
+    "@jupyterlab/codemirror": ^4.5.6
+    "@jupyterlab/coreutils": ^6.5.6
+    "@jupyterlab/docregistry": ^4.5.6
+    "@jupyterlab/documentsearch": ^4.5.6
+    "@jupyterlab/lsp": ^4.5.6
+    "@jupyterlab/rendermime": ^4.5.6
+    "@jupyterlab/statusbar": ^4.5.6
+    "@jupyterlab/toc": ^6.5.6
+    "@jupyterlab/translation": ^4.5.6
+    "@jupyterlab/ui-components": ^4.5.6
+    "@lumino/commands": ^2.3.3
+    "@lumino/coreutils": ^2.2.2
+    "@lumino/messaging": ^2.0.4
+    "@lumino/widgets": ^2.7.5
+    react: ^18.2.0
+    regexp-match-indices: ^1.0.2
+  checksum: 6735d2a6d47c5de27bf60fbb889dfffe1806fb25399dbdda16175cfffb011a9c25ac885aa9bbe8fbc72345f068beb3fc97da80223b09685f3c81ffb955541388
   languageName: node
   linkType: hard
 
@@ -1333,6 +1821,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/lsp@npm:^4.5.6":
+  version: 4.5.6
+  resolution: "@jupyterlab/lsp@npm:4.5.6"
+  dependencies:
+    "@jupyterlab/apputils": ^4.6.6
+    "@jupyterlab/codeeditor": ^4.5.6
+    "@jupyterlab/codemirror": ^4.5.6
+    "@jupyterlab/coreutils": ^6.5.6
+    "@jupyterlab/docregistry": ^4.5.6
+    "@jupyterlab/services": ^7.5.6
+    "@jupyterlab/translation": ^4.5.6
+    "@lumino/coreutils": ^2.2.2
+    "@lumino/disposable": ^2.1.5
+    "@lumino/signaling": ^2.1.5
+    "@lumino/widgets": ^2.7.5
+    lodash.mergewith: ^4.6.1
+    vscode-jsonrpc: ^6.0.0
+    vscode-languageserver-protocol: ^3.17.0
+    vscode-ws-jsonrpc: ~1.0.2
+  checksum: efaeaa3b8a740b40ad8fc5b99ab4777bd6287397844c84804ffa1000e8e349fd726b36259abf3ec13a062d86e6b4a1070bf998314149676176341f03204f5537
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/mainmenu@npm:^4.5.5":
   version: 4.5.5
   resolution: "@jupyterlab/mainmenu@npm:4.5.5"
@@ -1383,6 +1894,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/markedparser-extension@npm:^4.5.6":
+  version: 4.5.6
+  resolution: "@jupyterlab/markedparser-extension@npm:4.5.6"
+  dependencies:
+    "@jupyterlab/application": ^4.5.6
+    "@jupyterlab/codemirror": ^4.5.6
+    "@jupyterlab/coreutils": ^6.5.6
+    "@jupyterlab/mermaid": ^4.5.6
+    "@jupyterlab/rendermime": ^4.5.6
+    "@lumino/coreutils": ^2.2.2
+    marked: ^17.0.2
+    marked-gfm-heading-id: ^4.1.3
+    marked-mangle: ^1.1.12
+  checksum: 9f3b610497a18e34608f49f3dffade691c2b09c0ffbf44ab865dfe1f218571e4c99e9f518b811a97782c753986651525aa8cdfbfb40c4a286880736cffb7f74b
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/mermaid@npm:^4.5.5":
   version: 4.5.5
   resolution: "@jupyterlab/mermaid@npm:4.5.5"
@@ -1395,6 +1923,21 @@ __metadata:
     "@mermaid-js/layout-elk": ^0.2.0
     mermaid: ^11.12.3
   checksum: 3094bac75b42ddc72ea8a0fa08887464d347cd2d54bc632ede05cbd30ce1c744a92e40ac50fe9a129ae57eb069569683f3e2b3c6c0bd4aa8c6936adeb9826a56
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/mermaid@npm:^4.5.6":
+  version: 4.5.6
+  resolution: "@jupyterlab/mermaid@npm:4.5.6"
+  dependencies:
+    "@jupyterlab/apputils": ^4.6.6
+    "@jupyterlab/coreutils": ^6.5.6
+    "@jupyterlab/rendermime-interfaces": ^3.13.6
+    "@lumino/coreutils": ^2.2.2
+    "@lumino/widgets": ^2.7.5
+    "@mermaid-js/layout-elk": ^0.2.0
+    mermaid: ^11.12.3
+  checksum: 0ffef133463544bbf50c729c507a220e8386aab2727b27803ba8c315e308c1c25273dae5e5bc2f295802b9bbc46bd8fd3a0ee1a9d9d63a756be72da4c236c9e0
   languageName: node
   linkType: hard
 
@@ -1440,6 +1983,45 @@ __metadata:
   dependencies:
     "@lumino/coreutils": ^2.2.2
   checksum: 136f00cf215a7a4a9061d8874ac35191f5f65c62cdb7687578d77772d8d6fb866905710511986ef533a383826d1cc2807cfc58e5f7076b853703cae15b3c8bc8
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/notebook@npm:^4.2.0":
+  version: 4.5.6
+  resolution: "@jupyterlab/notebook@npm:4.5.6"
+  dependencies:
+    "@jupyter/ydoc": ^3.1.0
+    "@jupyterlab/apputils": ^4.6.6
+    "@jupyterlab/cells": ^4.5.6
+    "@jupyterlab/codeeditor": ^4.5.6
+    "@jupyterlab/codemirror": ^4.5.6
+    "@jupyterlab/coreutils": ^6.5.6
+    "@jupyterlab/docregistry": ^4.5.6
+    "@jupyterlab/documentsearch": ^4.5.6
+    "@jupyterlab/lsp": ^4.5.6
+    "@jupyterlab/markedparser-extension": ^4.5.6
+    "@jupyterlab/nbformat": ^4.5.6
+    "@jupyterlab/observables": ^5.5.6
+    "@jupyterlab/rendermime": ^4.5.6
+    "@jupyterlab/services": ^7.5.6
+    "@jupyterlab/settingregistry": ^4.5.6
+    "@jupyterlab/statusbar": ^4.5.6
+    "@jupyterlab/toc": ^6.5.6
+    "@jupyterlab/translation": ^4.5.6
+    "@jupyterlab/ui-components": ^4.5.6
+    "@lumino/algorithm": ^2.0.4
+    "@lumino/coreutils": ^2.2.2
+    "@lumino/disposable": ^2.1.5
+    "@lumino/domutils": ^2.0.4
+    "@lumino/dragdrop": ^2.1.8
+    "@lumino/messaging": ^2.0.4
+    "@lumino/polling": ^2.1.5
+    "@lumino/properties": ^2.0.4
+    "@lumino/signaling": ^2.1.5
+    "@lumino/virtualdom": ^2.0.4
+    "@lumino/widgets": ^2.7.5
+    react: ^18.2.0
+  checksum: 7e3fa18f0c9a99ec6dc5ba629fbd53f17539a1eb917b54f3d044cecf76e89bafa74fc854ad099bb1a9f364844990990714f016fa6a176dd2ccf8a4bb84bba1f2
   languageName: node
   linkType: hard
 
@@ -1517,6 +2099,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/outputarea@npm:^4.5.6":
+  version: 4.5.6
+  resolution: "@jupyterlab/outputarea@npm:4.5.6"
+  dependencies:
+    "@jupyterlab/apputils": ^4.6.6
+    "@jupyterlab/nbformat": ^4.5.6
+    "@jupyterlab/observables": ^5.5.6
+    "@jupyterlab/rendermime": ^4.5.6
+    "@jupyterlab/rendermime-interfaces": ^3.13.6
+    "@jupyterlab/services": ^7.5.6
+    "@jupyterlab/translation": ^4.5.6
+    "@lumino/algorithm": ^2.0.4
+    "@lumino/coreutils": ^2.2.2
+    "@lumino/disposable": ^2.1.5
+    "@lumino/messaging": ^2.0.4
+    "@lumino/properties": ^2.0.4
+    "@lumino/signaling": ^2.1.5
+    "@lumino/widgets": ^2.7.5
+  checksum: c0a42f0b12cc5b4c0ef20650d1f39a03dc0736db278ae2b1155927708e6783344603c1c221c7abf436f559551039a011f2ef39479992bd81e90622618df105e3
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/plugin-playground@workspace:.":
   version: 0.0.0-use.local
   resolution: "@jupyterlab/plugin-playground@workspace:."
@@ -1526,6 +2130,7 @@ __metadata:
     "@eslint/js": ^9.39.3
     "@jupyter-notebook/application": ^7.0.0
     "@jupyter-widgets/base": ^6.0.0
+    "@jupyter/chat": ^0.21.0
     "@jupyter/collaborative-drive": ^4.2.1
     "@jupyter/docprovider": ^4.1.1
     "@jupyter/eslint-plugin": ^0.0.1
@@ -1626,7 +2231,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/rendermime@npm:^4.5.5, @jupyterlab/rendermime@npm:^4.5.6":
+"@jupyterlab/rendermime@npm:^4.2.0, @jupyterlab/rendermime@npm:^4.5.5, @jupyterlab/rendermime@npm:^4.5.6":
   version: 4.5.6
   resolution: "@jupyterlab/rendermime@npm:4.5.6"
   dependencies:
@@ -1809,6 +2414,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/toc@npm:^6.5.6":
+  version: 6.5.6
+  resolution: "@jupyterlab/toc@npm:6.5.6"
+  dependencies:
+    "@jupyter/react-components": ^0.16.6
+    "@jupyterlab/apputils": ^4.6.6
+    "@jupyterlab/coreutils": ^6.5.6
+    "@jupyterlab/docregistry": ^4.5.6
+    "@jupyterlab/observables": ^5.5.6
+    "@jupyterlab/rendermime": ^4.5.6
+    "@jupyterlab/rendermime-interfaces": ^3.13.6
+    "@jupyterlab/translation": ^4.5.6
+    "@jupyterlab/ui-components": ^4.5.6
+    "@lumino/coreutils": ^2.2.2
+    "@lumino/disposable": ^2.1.5
+    "@lumino/messaging": ^2.0.4
+    "@lumino/signaling": ^2.1.5
+    "@lumino/widgets": ^2.7.5
+    react: ^18.2.0
+  checksum: 17344ecdcea645969f0f2d17a89c8afc7f0e3396b613ef8dc09fc47493e7099dcc3833c1d1b288cef440473f6c0b0cdef3b88a42d5b2c412d4a67a3e49da3f85
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/tooltip@npm:^4.5.5":
   version: 4.5.5
   resolution: "@jupyterlab/tooltip@npm:4.5.5"
@@ -1824,7 +2452,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/translation@npm:^4.5.0, @jupyterlab/translation@npm:^4.5.5, @jupyterlab/translation@npm:^4.5.6":
+"@jupyterlab/translation@npm:^4.2.0, @jupyterlab/translation@npm:^4.5.0, @jupyterlab/translation@npm:^4.5.5, @jupyterlab/translation@npm:^4.5.6":
   version: 4.5.6
   resolution: "@jupyterlab/translation@npm:4.5.6"
   dependencies:
@@ -1837,7 +2465,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/ui-components@npm:^4.5.5, @jupyterlab/ui-components@npm:^4.5.6, @jupyterlab/ui-components@npm:~4.5.6":
+"@jupyterlab/ui-components@npm:^4.2.0, @jupyterlab/ui-components@npm:^4.5.5, @jupyterlab/ui-components@npm:^4.5.6, @jupyterlab/ui-components@npm:~4.5.6":
   version: 4.5.6
   resolution: "@jupyterlab/ui-components@npm:4.5.6"
   dependencies:
@@ -2038,7 +2666,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lumino/algorithm@npm:^2.0.4":
+"@lumino/algorithm@npm:^2.0.0, @lumino/algorithm@npm:^2.0.4":
   version: 2.0.4
   resolution: "@lumino/algorithm@npm:2.0.4"
   checksum: ec1532fc294666fb483dd35082ec50ad979d0e9e1daf7a951ca045fd36a1ae88c7c73bf09c1aafed1ea826319f038ec2ed7058f58d214d5ed9f6a4cf61f232e8
@@ -2065,7 +2693,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lumino/commands@npm:^2.3.3":
+"@lumino/commands@npm:^2.0.0, @lumino/commands@npm:^2.3.3":
   version: 2.3.3
   resolution: "@lumino/commands@npm:2.3.3"
   dependencies:
@@ -2080,7 +2708,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lumino/coreutils@npm:^1 || ^2, @lumino/coreutils@npm:^1.11.0 || ^2.0.0, @lumino/coreutils@npm:^1.11.0 || ^2.2.2, @lumino/coreutils@npm:^2.2.1, @lumino/coreutils@npm:^2.2.2":
+"@lumino/coreutils@npm:^1 || ^2, @lumino/coreutils@npm:^1.11.0 || ^2.0.0, @lumino/coreutils@npm:^1.11.0 || ^2.2.2, @lumino/coreutils@npm:^2.0.0, @lumino/coreutils@npm:^2.2.1, @lumino/coreutils@npm:^2.2.2":
   version: 2.2.2
   resolution: "@lumino/coreutils@npm:2.2.2"
   dependencies:
@@ -2106,7 +2734,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lumino/disposable@npm:^1.10.0 || ^2.0.0, @lumino/disposable@npm:^2.1.4, @lumino/disposable@npm:^2.1.5":
+"@lumino/disposable@npm:^1.10.0 || ^2.0.0, @lumino/disposable@npm:^2.0.0, @lumino/disposable@npm:^2.1.4, @lumino/disposable@npm:^2.1.5":
   version: 2.1.5
   resolution: "@lumino/disposable@npm:2.1.5"
   dependencies:
@@ -2149,7 +2777,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lumino/polling@npm:^2.1.5":
+"@lumino/polling@npm:^2.0.0, @lumino/polling@npm:^2.1.5":
   version: 2.1.5
   resolution: "@lumino/polling@npm:2.1.5"
   dependencies:
@@ -2167,7 +2795,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lumino/signaling@npm:^1.10.0 || ^2.0.0, @lumino/signaling@npm:^2.1.4, @lumino/signaling@npm:^2.1.5":
+"@lumino/signaling@npm:^1.10.0 || ^2.0.0, @lumino/signaling@npm:^2.0.0, @lumino/signaling@npm:^2.1.4, @lumino/signaling@npm:^2.1.5":
   version: 2.1.5
   resolution: "@lumino/signaling@npm:2.1.5"
   dependencies:
@@ -2186,7 +2814,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lumino/widgets@npm:^1 || ^2, @lumino/widgets@npm:^1.37.2 || ^2.7.5, @lumino/widgets@npm:^2.7.0, @lumino/widgets@npm:^2.7.3, @lumino/widgets@npm:^2.7.5":
+"@lumino/widgets@npm:^1 || ^2, @lumino/widgets@npm:^1.37.2 || ^2.7.5, @lumino/widgets@npm:^2.0.0, @lumino/widgets@npm:^2.7.0, @lumino/widgets@npm:^2.7.3, @lumino/widgets@npm:^2.7.5":
   version: 2.7.5
   resolution: "@lumino/widgets@npm:2.7.5"
   dependencies:
@@ -2247,7 +2875,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@microsoft/fast-foundation@npm:^2.49.4":
+"@microsoft/fast-foundation@npm:^2.49.4, @microsoft/fast-foundation@npm:^2.50.0":
   version: 2.50.0
   resolution: "@microsoft/fast-foundation@npm:2.50.0"
   dependencies:
@@ -2259,12 +2887,185 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@microsoft/fast-react-wrapper@npm:^0.3.22":
+  version: 0.3.25
+  resolution: "@microsoft/fast-react-wrapper@npm:0.3.25"
+  dependencies:
+    "@microsoft/fast-element": ^1.14.0
+    "@microsoft/fast-foundation": ^2.50.0
+  peerDependencies:
+    react: ">=16.9.0"
+  checksum: 4c8e597eefd51c3091c25d0df28018b3283139178d6fd759532b40deb189f0422877308894fe55670edb82ed2a5b0138f2be8ef0b3df3ae518c14f75d6d0d577
+  languageName: node
+  linkType: hard
+
 "@microsoft/fast-web-utilities@npm:^5.4.1":
   version: 5.4.1
   resolution: "@microsoft/fast-web-utilities@npm:5.4.1"
   dependencies:
     exenv-es6: ^1.1.1
   checksum: 303e87847f962944f474e3716c3eb305668243916ca9e0719e26bb9a32346144bc958d915c103776b3e552cea0f0f6233f839fad66adfdf96a8436b947288ca7
+  languageName: node
+  linkType: hard
+
+"@mui/core-downloads-tracker@npm:^7.3.9":
+  version: 7.3.9
+  resolution: "@mui/core-downloads-tracker@npm:7.3.9"
+  checksum: 9e2658abcd68c05184a15643b6fe5c198e1dc09fbe45f80064b4133e787790f8a8af5d0d8dcf64771f6d4bb3f118e7ab6073fd23355a119bc517375211e6995c
+  languageName: node
+  linkType: hard
+
+"@mui/icons-material@npm:^7.3.2":
+  version: 7.3.9
+  resolution: "@mui/icons-material@npm:7.3.9"
+  dependencies:
+    "@babel/runtime": ^7.28.6
+  peerDependencies:
+    "@mui/material": ^7.3.9
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 355b73c854859b94994f2b98d5cb8a37d68faee49b3b14f75b3090189b3b3fece23907dfeb0e96f7ebcd976ffe619cde2df094147a39d73929ba0c8fcb9c18a0
+  languageName: node
+  linkType: hard
+
+"@mui/material@npm:^7.3.2":
+  version: 7.3.9
+  resolution: "@mui/material@npm:7.3.9"
+  dependencies:
+    "@babel/runtime": ^7.28.6
+    "@mui/core-downloads-tracker": ^7.3.9
+    "@mui/system": ^7.3.9
+    "@mui/types": ^7.4.12
+    "@mui/utils": ^7.3.9
+    "@popperjs/core": ^2.11.8
+    "@types/react-transition-group": ^4.4.12
+    clsx: ^2.1.1
+    csstype: ^3.2.3
+    prop-types: ^15.8.1
+    react-is: ^19.2.3
+    react-transition-group: ^4.4.5
+  peerDependencies:
+    "@emotion/react": ^11.5.0
+    "@emotion/styled": ^11.3.0
+    "@mui/material-pigment-css": ^7.3.9
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+    "@mui/material-pigment-css":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 4b0f51a8df5a9246cc9b8876073d8dafd8f0c07c79710782974c37410125989460beca6825882ddefc6107255a12c4c9ec52e08dac36659e0a328faa4f82611f
+  languageName: node
+  linkType: hard
+
+"@mui/private-theming@npm:^7.3.9":
+  version: 7.3.9
+  resolution: "@mui/private-theming@npm:7.3.9"
+  dependencies:
+    "@babel/runtime": ^7.28.6
+    "@mui/utils": ^7.3.9
+    prop-types: ^15.8.1
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 3c59d6f344ec94da35ba4fc7b212dc580d31a4579fbefe220696ffbd284514f1c8af8ce433e6060112b96f8bff81aaa665d76def1e82217dd6e106f5a05f540e
+  languageName: node
+  linkType: hard
+
+"@mui/styled-engine@npm:^7.3.9":
+  version: 7.3.9
+  resolution: "@mui/styled-engine@npm:7.3.9"
+  dependencies:
+    "@babel/runtime": ^7.28.6
+    "@emotion/cache": ^11.14.0
+    "@emotion/serialize": ^1.3.3
+    "@emotion/sheet": ^1.4.0
+    csstype: ^3.2.3
+    prop-types: ^15.8.1
+  peerDependencies:
+    "@emotion/react": ^11.4.1
+    "@emotion/styled": ^11.3.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+  checksum: 79b753b8895dd4bed2ed11184ade2b3aaf41c8215180344d9e53850c9ccf45c0767dc970353d8c3a0d06c402a919b14e1e73ba0de127ee0c0a4ce7b577e39922
+  languageName: node
+  linkType: hard
+
+"@mui/system@npm:^7.3.9":
+  version: 7.3.9
+  resolution: "@mui/system@npm:7.3.9"
+  dependencies:
+    "@babel/runtime": ^7.28.6
+    "@mui/private-theming": ^7.3.9
+    "@mui/styled-engine": ^7.3.9
+    "@mui/types": ^7.4.12
+    "@mui/utils": ^7.3.9
+    clsx: ^2.1.1
+    csstype: ^3.2.3
+    prop-types: ^15.8.1
+  peerDependencies:
+    "@emotion/react": ^11.5.0
+    "@emotion/styled": ^11.3.0
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: a8a8599ae3ac213809bb9e9a6d574282cc0666a657517c82453cbcff7b347ed047632dba0393263f5bdb650b8114ac40f41def5c1788d740c2d9c35f864b42eb
+  languageName: node
+  linkType: hard
+
+"@mui/types@npm:^7.4.12":
+  version: 7.4.12
+  resolution: "@mui/types@npm:7.4.12"
+  dependencies:
+    "@babel/runtime": ^7.28.6
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: f3217cc0a7beaf7f5e6557e5a55c8597d7a7bfc42f69472ac0fe2de6aeee6e7d85828f05a09ccc31de1261e713cf4203f597cd6b839e269829b534df2109ad98
+  languageName: node
+  linkType: hard
+
+"@mui/utils@npm:^7.3.9":
+  version: 7.3.9
+  resolution: "@mui/utils@npm:7.3.9"
+  dependencies:
+    "@babel/runtime": ^7.28.6
+    "@mui/types": ^7.4.12
+    "@types/prop-types": ^15.7.15
+    clsx: ^2.1.1
+    prop-types: ^15.8.1
+    react-is: ^19.2.3
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 13d4271081800f73131a43adc8b2e7144a7045e6d92f12265d61929fd319e822ce71a0947962583b98fe83ba8a393417d82e3bbe57cba5d3ba0df1e88a7377c9
   languageName: node
   linkType: hard
 
@@ -2287,6 +3088,13 @@ __metadata:
   dependencies:
     semver: ^7.3.5
   checksum: 897dac32eb37e011800112d406b9ea2ebd96f1dab01bb8fbeb59191b86f6825dffed6a89f3b6c824753d10f8735b76d630927bd7610e9e123b129ef2e5f02cb5
+  languageName: node
+  linkType: hard
+
+"@popperjs/core@npm:^2.11.8":
+  version: 2.11.8
+  resolution: "@popperjs/core@npm:2.11.8"
+  checksum: e5c69fdebf52a4012f6a1f14817ca8e9599cb1be73dd1387e1785e2ed5e5f0862ff817f420a87c7fc532add1f88a12e25aeb010ffcbdc98eace3d55ce2139cf0
   languageName: node
   linkType: hard
 
@@ -2757,7 +3565,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prop-types@npm:*":
+"@types/parse-json@npm:^4.0.0":
+  version: 4.0.2
+  resolution: "@types/parse-json@npm:4.0.2"
+  checksum: 5bf62eec37c332ad10059252fc0dab7e7da730764869c980b0714777ad3d065e490627be9f40fc52f238ffa3ac4199b19de4127196910576c2fe34dd47c7a470
+  languageName: node
+  linkType: hard
+
+"@types/prop-types@npm:*, @types/prop-types@npm:^15.7.15":
   version: 15.7.15
   resolution: "@types/prop-types@npm:15.7.15"
   checksum: 31aa2f59b28f24da6fb4f1d70807dae2aedfce090ec63eaf9ea01727a9533ef6eaf017de5bff99fbccad7d1c9e644f52c6c2ba30869465dd22b1a7221c29f356
@@ -2770,6 +3585,15 @@ __metadata:
   peerDependencies:
     "@types/react": ^18.0.0
   checksum: c8b63ec944d2a68992b4dba474003fe55ee1d949c4b9c8fe97eecb2290de23f76acfb670b2f7ceb46a5fc8e46808d1745369b03edda48a7a0cf730eff4c5d315
+  languageName: node
+  linkType: hard
+
+"@types/react-transition-group@npm:^4.4.12":
+  version: 4.4.12
+  resolution: "@types/react-transition-group@npm:4.4.12"
+  peerDependencies:
+    "@types/react": "*"
+  checksum: 13d36396cae4d3c316b03d4a0ba299f0d039c59368ba65e04b0c3dc06fd0a16f59d2c669c3e32d6d525a95423f156b84e550d26bff0bdd8df285f305f8f3a0ed
   languageName: node
   linkType: hard
 
@@ -3494,6 +4318,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"babel-plugin-macros@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "babel-plugin-macros@npm:3.1.0"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+    cosmiconfig: ^7.0.0
+    resolve: ^1.19.0
+  checksum: 765de4abebd3e4688ebdfbff8571ddc8cd8061f839bb6c3e550b0344a4027b04c60491f843296ce3f3379fb356cc873d57a9ee6694262547eb822c14a25be9a6
+  languageName: node
+  linkType: hard
+
 "backbone@npm:1.4.0":
   version: 1.4.0
   resolution: "backbone@npm:1.4.0"
@@ -3743,6 +4578,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"clsx@npm:^2.1.0, clsx@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "clsx@npm:2.1.1"
+  checksum: acd3e1ab9d8a433ecb3cc2f6a05ab95fe50b4a3cfc5ba47abb6cbf3754585fcb87b84e90c822a1f256c4198e3b41c7f6c391577ffc8678ad587fc0976b24fd57
+  languageName: node
+  linkType: hard
+
 "color-convert@npm:^1.9.0":
   version: 1.9.3
   resolution: "color-convert@npm:1.9.3"
@@ -3898,6 +4740,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"convert-source-map@npm:^1.5.0":
+  version: 1.9.0
+  resolution: "convert-source-map@npm:1.9.0"
+  checksum: dc55a1f28ddd0e9485ef13565f8f756b342f9a46c4ae18b843fe3c30c675d058d6a4823eff86d472f187b176f0adf51ea7b69ea38be34be4a63cbbf91b0593c8
+  languageName: node
+  linkType: hard
+
 "cose-base@npm:^1.0.0":
   version: 1.0.3
   resolution: "cose-base@npm:1.0.3"
@@ -3913,6 +4762,19 @@ __metadata:
   dependencies:
     layout-base: ^2.0.0
   checksum: 2e694f340bf216c71fc126d237578a4168e138720011d0b48c88bf9bfc7fd45f912eff2c603ef3d1307d6e3ce6f465ed382285a764a3a6620db590c5457d2557
+  languageName: node
+  linkType: hard
+
+"cosmiconfig@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "cosmiconfig@npm:7.1.0"
+  dependencies:
+    "@types/parse-json": ^4.0.0
+    import-fresh: ^3.2.1
+    parse-json: ^5.0.0
+    path-type: ^4.0.0
+    yaml: ^1.10.0
+  checksum: c53bf7befc1591b2651a22414a5e786cd5f2eeaa87f3678a3d49d6069835a9d8d1aef223728e98aa8fec9a95bf831120d245096db12abe019fecb51f5696c96f
   languageName: node
   linkType: hard
 
@@ -4010,7 +4872,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csstype@npm:^3.2.2":
+"csstype@npm:^3.0.2, csstype@npm:^3.2.2, csstype@npm:^3.2.3":
   version: 3.2.3
   resolution: "csstype@npm:3.2.3"
   checksum: cb882521b3398958a1ce6ca98c011aec0bde1c77ecaf8a1dd4db3b112a189939beae3b1308243b2fe50fc27eb3edeb0f73a5a4d91d928765dc6d5ecc7bda92ee
@@ -4549,6 +5411,16 @@ __metadata:
   version: 1.0.0
   resolution: "delayed-stream@npm:1.0.0"
   checksum: 46fe6e83e2cb1d85ba50bd52803c68be9bd953282fa7096f51fc29edd5d67ff84ff753c51966061e5ba7cb5e47ef6d36a91924eddb7f3f3483b1c560f77a0020
+  languageName: node
+  linkType: hard
+
+"dom-helpers@npm:^5.0.1":
+  version: 5.2.1
+  resolution: "dom-helpers@npm:5.2.1"
+  dependencies:
+    "@babel/runtime": ^7.8.7
+    csstype: ^3.0.2
+  checksum: 863ba9e086f7093df3376b43e74ce4422571d404fc9828bf2c56140963d5edf0e56160f9b2f3bb61b282c07f8fc8134f023c98fd684bddcb12daf7b0f14d951c
   languageName: node
   linkType: hard
 
@@ -5135,7 +6007,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-root@npm:^1.0.0":
+"find-root@npm:^1.0.0, find-root@npm:^1.1.0":
   version: 1.1.0
   resolution: "find-root@npm:1.1.0"
   checksum: b2a59fe4b6c932eef36c45a048ae8f93c85640212ebe8363164814990ee20f154197505965f3f4f102efc33bfb1cbc26fd17c4a2fc739ebc51b886b137cbefaf
@@ -5470,6 +6342,15 @@ __metadata:
   dependencies:
     function-bind: ^1.1.2
   checksum: e8516f776a15149ca6c6ed2ae3110c417a00b62260e222590e54aa367cbcd6ed99122020b37b7fbdf05748df57b265e70095d7bf35a47660587619b15ffb93db
+  languageName: node
+  linkType: hard
+
+"hoist-non-react-statics@npm:^3.3.1":
+  version: 3.3.2
+  resolution: "hoist-non-react-statics@npm:3.3.2"
+  dependencies:
+    react-is: ^16.7.0
+  checksum: b1538270429b13901ee586aa44f4cc3ecd8831c061d06cb8322e50ea17b3f5ce4d0e2e66394761e6c8e152cd8c34fb3b4b690116c6ce2bd45b18c746516cb9e8
   languageName: node
   linkType: hard
 
@@ -6118,6 +6999,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsesc@npm:^3.0.2":
+  version: 3.1.0
+  resolution: "jsesc@npm:3.1.0"
+  bin:
+    jsesc: bin/jsesc
+  checksum: 19c94095ea026725540c0d29da33ab03144f6bcf2d4159e4833d534976e99e0c09c38cefa9a575279a51fc36b31166f8d6d05c9fe2645d5f15851d690b41f17f
+  languageName: node
+  linkType: hard
+
 "json-buffer@npm:3.0.1":
   version: 3.0.1
   resolution: "json-buffer@npm:3.0.1"
@@ -6132,7 +7022,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-parse-even-better-errors@npm:^2.3.1":
+"json-parse-even-better-errors@npm:^2.3.0, json-parse-even-better-errors@npm:^2.3.1":
   version: 2.3.1
   resolution: "json-parse-even-better-errors@npm:2.3.1"
   checksum: 798ed4cf3354a2d9ccd78e86d2169515a0097a5c133337807cdf7f1fc32e1391d207ccfc276518cc1d7d8d4db93288b8a50ba4293d212ad1336e52a8ec0a941f
@@ -6413,6 +7303,13 @@ __metadata:
     webpack:
       optional: true
   checksum: 6208bd2060d200fbffbcc89702c929d50c5a4a3f2158b046cf813b3f7f728bbbe4611b9fea2d67843bb5e7d64ad9122cc368a19ac73f5c4ad41765e6283bdc0c
+  languageName: node
+  linkType: hard
+
+"lines-and-columns@npm:^1.1.6":
+  version: 1.2.4
+  resolution: "lines-and-columns@npm:1.2.4"
+  checksum: 0c37f9f7fa212b38912b7145e1cd16a5f3cd34d782441c3e6ca653485d326f58b3caccda66efce1c5812bde4961bbde3374fae4b0d11bf1226152337f3894aa5
   languageName: node
   linkType: hard
 
@@ -7094,6 +7991,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse-json@npm:^5.0.0":
+  version: 5.2.0
+  resolution: "parse-json@npm:5.2.0"
+  dependencies:
+    "@babel/code-frame": ^7.0.0
+    error-ex: ^1.3.1
+    json-parse-even-better-errors: ^2.3.0
+    lines-and-columns: ^1.1.6
+  checksum: 62085b17d64da57f40f6afc2ac1f4d95def18c4323577e1eced571db75d9ab59b297d1d10582920f84b15985cbfc6b6d450ccbf317644cfa176f3ed982ad87e2
+  languageName: node
+  linkType: hard
+
 "parse-srcset@npm:^1.0.2":
   version: 1.0.2
   resolution: "parse-srcset@npm:1.0.2"
@@ -7175,6 +8084,13 @@ __metadata:
   dependencies:
     pify: ^3.0.0
   checksum: 735b35e256bad181f38fa021033b1c33cfbe62ead42bb2222b56c210e42938eecb272ae1949f3b6db4ac39597a61b44edd8384623ec4d79bfdc9a9c0f12537a6
+  languageName: node
+  linkType: hard
+
+"path-type@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "path-type@npm:4.0.0"
+  checksum: 5b1e2daa247062061325b8fdbfd1fb56dde0a448fb1455453276ea18c60685bdad23a445dc148cf87bc216be1573357509b7d4060494a6fd768c7efad833ee45
   languageName: node
   linkType: hard
 
@@ -7379,7 +8295,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.6.1, prop-types@npm:^15.8.1":
+"prop-types@npm:^15.6.1, prop-types@npm:^15.6.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -7444,7 +8360,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.13.1":
+"react-is@npm:^16.13.1, react-is@npm:^16.7.0":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: f7a19ac3496de32ca9ae12aa030f00f14a3d45374f1ceca0af707c831b2a6098ef0d6bdae51bd437b0a306d7f01d4677fcc8de7c0d331eb47ad0f46130e53c5f
@@ -7458,6 +8374,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-is@npm:^19.2.3":
+  version: 19.2.4
+  resolution: "react-is@npm:19.2.4"
+  checksum: 646d4f0f11b50131f3f7ac5b50d12b79de35be20fa84bce33fd3fc91557589e388562cb6203b5237098fd983cd1cdf12c5fb952b7f9903ac014de9a5a6cc7e28
+  languageName: node
+  linkType: hard
+
 "react-paginate@npm:^6.3.2":
   version: 6.5.0
   resolution: "react-paginate@npm:6.5.0"
@@ -7466,6 +8389,21 @@ __metadata:
   peerDependencies:
     react: ^16.0.0
   checksum: 39397de9a330e9ed16b2422d5893f47e16b5f7f188bf59ce4f60beeb16cfdba0ba76c7f0ca1b733d7282821a4e984ae64fb1a7086ecc22b416af95c1ff974fec
+  languageName: node
+  linkType: hard
+
+"react-transition-group@npm:^4.4.5":
+  version: 4.4.5
+  resolution: "react-transition-group@npm:4.4.5"
+  dependencies:
+    "@babel/runtime": ^7.5.5
+    dom-helpers: ^5.0.1
+    loose-envify: ^1.4.0
+    prop-types: ^15.6.2
+  peerDependencies:
+    react: ">=16.6.0"
+    react-dom: ">=16.6.0"
+  checksum: 75602840106aa9c6545149d6d7ae1502fb7b7abadcce70a6954c4b64a438ff1cd16fc77a0a1e5197cdd72da398f39eb929ea06f9005c45b132ed34e056ebdeb1
   languageName: node
   linkType: hard
 
@@ -7604,7 +8542,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.10.0, resolve@npm:^1.20.0":
+"resolve@npm:^1.10.0, resolve@npm:^1.19.0, resolve@npm:^1.20.0":
   version: 1.22.11
   resolution: "resolve@npm:1.22.11"
   dependencies:
@@ -7617,7 +8555,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>":
+"resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>":
   version: 1.22.11
   resolution: "resolve@patch:resolve@npm%3A1.22.11#~builtin<compat/resolve>::version=1.22.11&hash=c3c19d"
   dependencies:
@@ -8013,6 +8951,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map@npm:^0.5.7":
+  version: 0.5.7
+  resolution: "source-map@npm:0.5.7"
+  checksum: 5dc2043b93d2f194142c7f38f74a24670cd7a0063acdaf4bf01d2964b402257ae843c2a8fa822ad5b71013b5fcafa55af7421383da919752f22ff488bc553f4d
+  languageName: node
+  linkType: hard
+
 "source-map@npm:^0.6.0, source-map@npm:^0.6.1, source-map@npm:~0.6.1":
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
@@ -8168,6 +9113,13 @@ __metadata:
   version: 4.1.3
   resolution: "style-mod@npm:4.1.3"
   checksum: 2372098b8747ea0d662084e88961f48d49796b2aca6f8f7de2546aa73059e869db1149325106eba37267afd9e7f97109be6679a6011c48ae1d5c0b6382a4d163
+  languageName: node
+  linkType: hard
+
+"stylis@npm:4.2.0":
+  version: 4.2.0
+  resolution: "stylis@npm:4.2.0"
+  checksum: 0eb6cc1b866dc17a6037d0a82ac7fa877eba6a757443e79e7c4f35bacedbf6421fadcab4363b39667b43355cbaaa570a3cde850f776498e5450f32ed2f9b7584
   languageName: node
   linkType: hard
 
@@ -9106,6 +10058,13 @@ __metadata:
   version: 5.0.0
   resolution: "yallist@npm:5.0.0"
   checksum: eba51182400b9f35b017daa7f419f434424410691bbc5de4f4240cc830fdef906b504424992700dc047f16b4d99100a6f8b8b11175c193f38008e9c96322b6a5
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^1.10.0":
+  version: 1.10.3
+  resolution: "yaml@npm:1.10.3"
+  checksum: 6a2dd3582f4fbcc8d0e32dc26d1a42f72a901eb6ae8fad616bd720514b11a53a64eabc21dba97fbcd951c7c0e1963502313789d93a753e7786e7452376498be5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
closes #106 


This update adds an insertion dropdown for commands so users can choose the flow they want. In Insert mode, clicking + adds the command right at the current cursor position for a fast manual action. In AI mode, it does not insert immediately; it opens the AI chat and pre-fills a prompt so the user can review or adjust before sending. This gives both a quick, direct option and a guided AI option in the same UI.


