### PR TITLE
Fix license files in extension examples

### DIFF
--- a/docs/jupyter_lite_config.json
+++ b/docs/jupyter_lite_config.json
@@ -5,7 +5,13 @@
       "typescript": {
         "name": "typescript",
         "extensions": [".ts"],
-        "mimetypes": ["text/plain"],
+        "mimeTypes": ["text/plain"],
+        "fileFormat": "text"
+      },
+      "extensionless-text": {
+        "name": "extensionless-text",
+        "extensions": [""],
+        "mimeTypes": ["text/plain"],
         "fileFormat": "text"
       }
     }


### PR DESCRIPTION
Fixes #150 

This PR resolves the issue by fixing the license file behavior in extension examples so these files display correctly and consistently in the docs experience.