### PR TITLE
Update `jupyterlite-ai` to v0.15 

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -24,4 +24,4 @@ dependencies:
   - jupyterlab-js-logs>=1.1,<2
   # use the same AI package in Binder and JupyterLite deployments
   - pip:
-      - jupyterlite-ai>=0.12,<1
+      - jupyterlite-ai>=0.15,<1

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - jupyterlite-core>=0.7.0,<0.8
   - jupyterlite-sphinx>=0.22.0,<0.23
   - jupyterlite-pyodide-kernel>=0.7.0,<0.8
-  - jupyterlite-ai>=0.12,<1
   - nodejs=18
   - pip:
       - build
+      - jupyterlite-ai>=0.15,<1


### PR DESCRIPTION
Testing if the new version fixes the `[Object object]` issue as per discussion in [#jupyter-ai > jupyterlite/ai &#91;Object object&#93;](https://jupyter.zulipchat.com/#narrow/channel/475130-jupyter-ai/topic/jupyterlite.2Fai.20.5BObject.20object.5D/with/584682775).

Maybe we could also address #155 in this PR once v0.15 is available on conda-forge.