### PR TITLE
Fix Toolbar button alignment

### DIFF
--- a/style/base.css
+++ b/style/base.css
@@ -386,6 +386,19 @@
 
 .jp-Toolbar > .jp-Toolbar-item[data-jp-item-name='export-extension'] {
   margin-left: auto;
+  order: 1001;
+}
+
+.jp-Toolbar > .jp-Toolbar-item[data-jp-item-name='share-extension-link'] {
+  order: 1002;
+}
+
+.jp-Toolbar > .jp-Toolbar-item[data-jp-item-name='reject-all-diff'] {
+  order: 1003;
+}
+
+.jp-Toolbar > .jp-Toolbar-item[data-jp-item-name='accept-all-diff'] {
+  order: 1004;
 }
 
 @keyframes jp-PluginPlayground-lineChangePulse {


### PR DESCRIPTION
Fixes #158

This PR fixes a toolbar alignment issue where the Share and Export buttons could shift to the left when AI edit actions are shown.  

