### PR TITLE
Add shared-file loading hint

### DIFF
--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -66,7 +66,7 @@
   "jupyter.lab.toolbars": {
     "Editor": [
       {
-        "name": "insert",
+        "name": "load-as-extension",
         "command": "plugin-playground:load-as-extension",
         "rank": 20
       },

--- a/src/components/url-load-hint.ts
+++ b/src/components/url-load-hint.ts
@@ -1,0 +1,64 @@
+export interface IFloatingUrlLoadHintOptions {
+  parent: HTMLElement;
+  title: string;
+  description: string;
+  closeAriaLabel: string;
+  onClose: () => void;
+}
+
+export interface IFloatingUrlLoadHint {
+  hide: () => void;
+  setPosition: (left: number, top: number) => void;
+  show: () => void;
+  dispose: () => void;
+}
+
+export function createFloatingUrlLoadHint(
+  options: IFloatingUrlLoadHintOptions
+): IFloatingUrlLoadHint {
+  const hintNode = document.createElement('div');
+  hintNode.className =
+    'jp-PluginPlayground-urlLoadedHintCard jp-PluginPlayground-urlLoadedFloatingHint';
+
+  const titleNode = document.createElement('span');
+  titleNode.className = 'jp-PluginPlayground-urlLoadedHintText';
+  titleNode.textContent = options.title;
+
+  const descriptionNode = document.createElement('span');
+  descriptionNode.className = 'jp-PluginPlayground-urlLoadedHintDescription';
+  descriptionNode.textContent = options.description;
+
+  const closeButton = document.createElement('button');
+  closeButton.type = 'button';
+  closeButton.className = 'jp-PluginPlayground-urlLoadedHintClose';
+  closeButton.textContent = '×';
+  closeButton.setAttribute('aria-label', options.closeAriaLabel);
+
+  const onCloseButtonClick = (event: MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    options.onClose();
+  };
+
+  closeButton.addEventListener('click', onCloseButtonClick);
+  hintNode.append(titleNode, descriptionNode, closeButton);
+  hintNode.style.display = 'none';
+  options.parent.appendChild(hintNode);
+
+  return {
+    hide: () => {
+      hintNode.style.display = 'none';
+    },
+    setPosition: (left: number, top: number) => {
+      hintNode.style.left = `${left}px`;
+      hintNode.style.top = `${top}px`;
+    },
+    show: () => {
+      hintNode.style.display = 'flex';
+    },
+    dispose: () => {
+      closeButton.removeEventListener('click', onCloseButtonClick);
+      hintNode.remove();
+    }
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,7 @@ import {
 } from './token-sidebar';
 
 import { ExampleSidebar, filterExampleRecords } from './example-sidebar';
+import { createFloatingUrlLoadHint } from './components/url-load-hint';
 
 import { tokenSidebarIcon } from './icons';
 
@@ -298,6 +299,11 @@ const ARCHIVE_FILE_READ_CONCURRENCY = 8;
 const SHARE_URL_WARN_LENGTH = 1800;
 const SHARE_URL_MAX_LENGTH = 8000;
 const SHARED_LINKS_ROOT = 'plugin-playground-shared';
+const URL_LOADED_EDITOR_HINT_CLASS = 'jp-PluginPlayground-urlLoadedEditorHint';
+const URL_LOADED_EDITOR_HINT_TITLE = 'Load as Extension';
+const URL_LOADED_EDITOR_HINT_MESSAGE =
+  'Run this shared file in the playground.';
+const URL_LOADED_EDITOR_HINT_DISMISS_LABEL = 'Close load as extension hint';
 const NOTEBOOK_FILE_BROWSER_FACTORY = 'FileBrowser';
 const NOTEBOOK_NEW_DROPDOWN_TOOLBAR_ITEM = 'new-dropdown';
 const NOTEBOOK_TREE_OPEN_SIDEBAR_KEY =
@@ -349,6 +355,9 @@ class PluginPlayground {
       execute: async () => {
         const currentWidget = editorTracker.currentWidget;
         if (currentWidget) {
+          if (this._sharedFileCueWidgetId === currentWidget.id) {
+            this._dismissSharedFileCue?.();
+          }
           const currentText = currentWidget.context.model.toString();
           return this._queuePluginLoad(currentText, currentWidget.context.path);
         }
@@ -813,6 +822,89 @@ class PluginPlayground {
     return toggleWidget;
   }
 
+  private _showSharedFileToolbarCue(
+    widget: IDocumentWidget<FileEditor>,
+    sourcePath: string
+  ): void {
+    this._dismissSharedFileCue?.();
+
+    let isDisposed = false;
+    let rafId: number | null = null;
+    const normalizedSourcePath = ContentUtils.normalizeContentsPath(sourcePath);
+    const loadToolbarItemSelector =
+      '.jp-Toolbar > .jp-Toolbar-item[data-jp-item-name="insert"]';
+
+    const queueHintPositionRefresh = () => {
+      if (rafId !== null || isDisposed) {
+        return;
+      }
+      rafId = window.requestAnimationFrame(() => {
+        rafId = null;
+        if (isDisposed) {
+          return;
+        }
+        const loadItemNode = widget.node.querySelector(
+          loadToolbarItemSelector
+        ) as HTMLElement | null;
+        if (!loadItemNode) {
+          return;
+        }
+        floatingHint.setPosition(
+          loadItemNode.offsetLeft,
+          loadItemNode.offsetTop + loadItemNode.offsetHeight + 3
+        );
+      });
+    };
+
+    const disposeCue = () => {
+      if (isDisposed) {
+        return;
+      }
+      isDisposed = true;
+      if (rafId !== null) {
+        window.cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+      widget.removeClass(URL_LOADED_EDITOR_HINT_CLASS);
+      window.removeEventListener('resize', queueHintPositionRefresh);
+      widget.context.pathChanged.disconnect(onPathChanged);
+      widget.disposed.disconnect(disposeCue);
+      if (this._sharedFileCueWidgetId === widget.id) {
+        this._sharedFileCueWidgetId = null;
+        this._dismissSharedFileCue = null;
+      }
+      floatingHint.dispose();
+    };
+
+    const floatingHint = createFloatingUrlLoadHint({
+      parent: widget.node,
+      title: URL_LOADED_EDITOR_HINT_TITLE,
+      description: URL_LOADED_EDITOR_HINT_MESSAGE,
+      closeAriaLabel: URL_LOADED_EDITOR_HINT_DISMISS_LABEL,
+      onClose: disposeCue
+    });
+
+    widget.addClass(URL_LOADED_EDITOR_HINT_CLASS);
+    floatingHint.show();
+    queueHintPositionRefresh();
+    window.addEventListener('resize', queueHintPositionRefresh);
+
+    this._sharedFileCueWidgetId = widget.id;
+    this._dismissSharedFileCue = disposeCue;
+    const onPathChanged = (
+      _context: DocumentRegistry.Context,
+      newPath: string
+    ) => {
+      if (
+        ContentUtils.normalizeContentsPath(newPath) !== normalizedSourcePath
+      ) {
+        disposeCue();
+      }
+    };
+    widget.context.pathChanged.connect(onPathChanged);
+    widget.disposed.connect(disposeCue);
+  }
+
   private _queuePluginLoad(
     pluginSource: string,
     path: string
@@ -1171,6 +1263,19 @@ class PluginPlayground {
         path: restoredPath,
         factory: 'Editor'
       });
+      let restoredWidget: IDocumentWidget<FileEditor> | null = null;
+      this.editorTracker.forEach(candidate => {
+        if (
+          !restoredWidget &&
+          ContentUtils.normalizeContentsPath(candidate.context.path) ===
+            restoredPath
+        ) {
+          restoredWidget = candidate;
+        }
+      });
+      if (restoredWidget) {
+        this._showSharedFileToolbarCue(restoredWidget, restoredPath);
+      }
       Notification.success(
         `Opened shared plugin from URL at "${restoredPath}" (1 file). `,
         {
@@ -2764,6 +2869,8 @@ class PluginPlayground {
   >();
   private readonly _loadOnSaveByFile = new Set<string>();
   private readonly _loadOnSaveToggleRefreshers = new Set<() => void>();
+  private _sharedFileCueWidgetId: string | null = null;
+  private _dismissSharedFileCue: (() => void) | null = null;
   private readonly _tokenMap = new Map<string, Token<string>>();
   private readonly _tokenDescriptionMap = new Map<string, string>();
   private readonly _documentationWidgets = new Map<

--- a/src/index.ts
+++ b/src/index.ts
@@ -830,9 +830,11 @@ class PluginPlayground {
 
     let isDisposed = false;
     let rafId: number | null = null;
+    let hasShownFloatingHint = false;
+    let remainingPositionRetries = 10;
     const normalizedSourcePath = ContentUtils.normalizeContentsPath(sourcePath);
     const loadToolbarItemSelector =
-      '.jp-Toolbar > .jp-Toolbar-item[data-jp-item-name="insert"]';
+      '.jp-Toolbar > .jp-Toolbar-item[data-jp-item-name="load-as-extension"]';
 
     const queueHintPositionRefresh = () => {
       if (rafId !== null || isDisposed) {
@@ -847,12 +849,20 @@ class PluginPlayground {
           loadToolbarItemSelector
         ) as HTMLElement | null;
         if (!loadItemNode) {
+          if (!hasShownFloatingHint && remainingPositionRetries > 0) {
+            remainingPositionRetries--;
+            queueHintPositionRefresh();
+          }
           return;
         }
         floatingHint.setPosition(
           loadItemNode.offsetLeft,
           loadItemNode.offsetTop + loadItemNode.offsetHeight + 3
         );
+        if (!hasShownFloatingHint) {
+          hasShownFloatingHint = true;
+          floatingHint.show();
+        }
       });
     };
 
@@ -885,7 +895,6 @@ class PluginPlayground {
     });
 
     widget.addClass(URL_LOADED_EDITOR_HINT_CLASS);
-    floatingHint.show();
     queueHintPositionRefresh();
     window.addEventListener('resize', queueHintPositionRefresh);
 

--- a/style/base.css
+++ b/style/base.css
@@ -386,25 +386,25 @@
 
 .jp-PluginPlayground-urlLoadedEditorHint
   .jp-Toolbar
-  > .jp-Toolbar-item[data-jp-item-name='insert']
+  > .jp-Toolbar-item[data-jp-item-name='load-as-extension']
   .jp-ToolbarButtonComponent {
   color: var(--jp-success-color1, #2e7d32);
 }
 
 .jp-PluginPlayground-urlLoadedEditorHint
   .jp-Toolbar
-  > .jp-Toolbar-item[data-jp-item-name='insert']
+  > .jp-Toolbar-item[data-jp-item-name='load-as-extension']
   .jp-ToolbarButtonComponent:hover,
 .jp-PluginPlayground-urlLoadedEditorHint
   .jp-Toolbar
-  > .jp-Toolbar-item[data-jp-item-name='insert']
+  > .jp-Toolbar-item[data-jp-item-name='load-as-extension']
   .jp-ToolbarButtonComponent:focus-visible {
   color: var(--jp-success-color0, #1f7a1f);
 }
 
 .jp-PluginPlayground-urlLoadedEditorHint
   .jp-Toolbar
-  > .jp-Toolbar-item[data-jp-item-name='insert']
+  > .jp-Toolbar-item[data-jp-item-name='load-as-extension']
   .jp-ToolbarButtonComponent
   svg {
   color: currentColor;
@@ -412,7 +412,7 @@
 
 .jp-PluginPlayground-urlLoadedEditorHint
   .jp-Toolbar
-  > .jp-Toolbar-item[data-jp-item-name='insert']
+  > .jp-Toolbar-item[data-jp-item-name='load-as-extension']
   .jp-ToolbarButtonComponent
   svg
   * {
@@ -474,7 +474,6 @@
   align-items: center;
   background: transparent;
   border: none;
-  border-radius: 999px;
   color: var(--jp-ui-font-color2);
   cursor: pointer;
   display: inline-flex;
@@ -490,11 +489,16 @@
   width: 20px;
 }
 
-.jp-PluginPlayground-urlLoadedHintClose:hover,
+.jp-PluginPlayground-urlLoadedHintClose:hover {
+  background: var(--jp-layout-color2);
+  color: var(--jp-ui-font-color0);
+}
+
 .jp-PluginPlayground-urlLoadedHintClose:focus-visible {
   background: var(--jp-layout-color2);
   color: var(--jp-ui-font-color0);
-  outline: none;
+  outline: var(--jp-border-width) solid var(--jp-brand-color1);
+  outline-offset: 2px;
 }
 
 .jp-Toolbar > .jp-Toolbar-item[data-jp-item-name='export-extension'] {

--- a/style/base.css
+++ b/style/base.css
@@ -384,6 +384,119 @@
   color: var(--jp-ui-font-color2);
 }
 
+.jp-PluginPlayground-urlLoadedEditorHint
+  .jp-Toolbar
+  > .jp-Toolbar-item[data-jp-item-name='insert']
+  .jp-ToolbarButtonComponent {
+  color: var(--jp-success-color1, #2e7d32);
+}
+
+.jp-PluginPlayground-urlLoadedEditorHint
+  .jp-Toolbar
+  > .jp-Toolbar-item[data-jp-item-name='insert']
+  .jp-ToolbarButtonComponent:hover,
+.jp-PluginPlayground-urlLoadedEditorHint
+  .jp-Toolbar
+  > .jp-Toolbar-item[data-jp-item-name='insert']
+  .jp-ToolbarButtonComponent:focus-visible {
+  color: var(--jp-success-color0, #1f7a1f);
+}
+
+.jp-PluginPlayground-urlLoadedEditorHint
+  .jp-Toolbar
+  > .jp-Toolbar-item[data-jp-item-name='insert']
+  .jp-ToolbarButtonComponent
+  svg {
+  color: currentColor;
+}
+
+.jp-PluginPlayground-urlLoadedEditorHint
+  .jp-Toolbar
+  > .jp-Toolbar-item[data-jp-item-name='insert']
+  .jp-ToolbarButtonComponent
+  svg
+  * {
+  fill: currentColor;
+  stroke: currentColor;
+}
+
+.jp-PluginPlayground-urlLoadedHintCard {
+  background: var(--jp-layout-color1);
+  border: 1px solid var(--jp-border-color1);
+  border-radius: 10px;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.28);
+  color: var(--jp-ui-font-color1);
+  display: flex;
+  flex-direction: column;
+  font-size: var(--jp-ui-font-size0);
+  gap: 4px;
+  line-height: 1.3;
+  max-width: 240px;
+  min-width: 200px;
+  padding: 10px 12px;
+  position: relative;
+}
+
+.jp-PluginPlayground-urlLoadedFloatingHint {
+  left: 0;
+  position: absolute;
+  top: 0;
+  z-index: 20;
+}
+
+.jp-PluginPlayground-urlLoadedHintCard::before {
+  background: var(--jp-layout-color1);
+  border-left: 1px solid var(--jp-border-color1);
+  border-top: 1px solid var(--jp-border-color1);
+  content: '';
+  height: 12px;
+  left: 6px;
+  position: absolute;
+  top: -7px;
+  transform: rotate(45deg);
+  width: 12px;
+}
+
+.jp-PluginPlayground-urlLoadedHintText {
+  font-size: var(--jp-ui-font-size1);
+  font-weight: 600;
+  line-height: 1.2;
+  padding-right: 18px;
+}
+
+.jp-PluginPlayground-urlLoadedHintDescription {
+  color: var(--jp-ui-font-color2);
+  font-size: var(--jp-ui-font-size0);
+  line-height: 1.35;
+}
+
+.jp-PluginPlayground-urlLoadedHintClose {
+  align-items: center;
+  background: transparent;
+  border: none;
+  border-radius: 999px;
+  color: var(--jp-ui-font-color2);
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 15px;
+  height: 20px;
+  justify-content: center;
+  line-height: 1;
+  margin: 0;
+  padding: 0;
+  position: absolute;
+  right: 6px;
+  top: 6px;
+  width: 20px;
+}
+
+.jp-PluginPlayground-urlLoadedHintClose:hover,
+.jp-PluginPlayground-urlLoadedHintClose:focus-visible {
+  background: var(--jp-layout-color2);
+  color: var(--jp-ui-font-color0);
+  outline: none;
+}
+
 .jp-Toolbar > .jp-Toolbar-item[data-jp-item-name='export-extension'] {
   margin-left: auto;
   order: 1001;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,5 @@
     "target": "es2022",
     "types": []
   },
-  "include": ["src/*"]
+  "include": ["src/**/*"]
 }

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -846,7 +846,7 @@ export default plugin;
         return null;
       }
       const loadItem = root.querySelector(
-        '.jp-Toolbar > .jp-Toolbar-item[data-jp-item-name="insert"]'
+        '.jp-Toolbar > .jp-Toolbar-item[data-jp-item-name="load-as-extension"]'
       ) as HTMLElement | null;
       const loadButton = loadItem?.querySelector(
         '.jp-ToolbarButtonComponent'

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -731,15 +731,17 @@ test('loads a shared plugin from URL and clears query param', async ({
   tmpPath
 }) => {
   const projectRoot = `${tmpPath}/share-load-command-test`;
+  const sharedPluginId = 'share-load-command-test:plugin';
+  const sharedToggleCommand = 'share-load-command-test:toggle';
   const sourceFilename = 'share-load-entry.ts';
   const sourcePath = `${projectRoot}/src/${sourceFilename}`;
   const packageJsonPath = `${projectRoot}/package.json`;
   const sharedPluginSource = `
 const plugin = {
-  id: 'share-load-command-test:plugin',
+  id: '${sharedPluginId}',
   autoStart: true,
   activate: app => {
-    app.commands.addCommand('share-load-command-test:toggle', {
+    app.commands.addCommand('${sharedToggleCommand}', {
       label: 'Share Load Toggle',
       execute: () => {
         return undefined;
@@ -834,6 +836,89 @@ export default plugin;
         'Shared file was not restored under plugin-playground-shared.'
       );
     }
+    await page.filebrowser.open(restoredPath);
+    expect(await page.activity.activateTab(sourceFilename)).toBe(true);
+
+    const toolbarState = await page.evaluate(() => {
+      const current = window.jupyterapp.shell.currentWidget as FileEditorWidget;
+      const root = current?.node as HTMLElement | undefined;
+      if (!root) {
+        return null;
+      }
+      const loadItem = root.querySelector(
+        '.jp-Toolbar > .jp-Toolbar-item[data-jp-item-name="insert"]'
+      ) as HTMLElement | null;
+      const loadButton = loadItem?.querySelector(
+        '.jp-ToolbarButtonComponent'
+      ) as HTMLElement | null;
+      const floatingHint = root.querySelector(
+        '.jp-PluginPlayground-urlLoadedFloatingHint'
+      ) as HTMLElement | null;
+      const exportButton = root.querySelector(
+        '.jp-Toolbar > .jp-Toolbar-item[data-jp-item-name="export-extension"] .jp-ToolbarButtonComponent'
+      ) as HTMLElement | null;
+      const loadIcon = loadButton?.querySelector('svg') as SVGElement | null;
+      const exportIcon = exportButton?.querySelector(
+        'svg'
+      ) as SVGElement | null;
+      return {
+        hasHintClass: root.classList.contains(
+          'jp-PluginPlayground-urlLoadedEditorHint'
+        ),
+        hintLabel:
+          floatingHint
+            ?.querySelector('.jp-PluginPlayground-urlLoadedHintText')
+            ?.textContent?.trim() ?? '',
+        hasHintCloseButton: !!floatingHint?.querySelector(
+          '.jp-PluginPlayground-urlLoadedHintClose'
+        ),
+        hasVisibleFloatingHint:
+          !!floatingHint &&
+          window.getComputedStyle(floatingHint).display !== 'none',
+        loadButtonIconColor: loadIcon
+          ? window.getComputedStyle(loadIcon).color
+          : '',
+        exportButtonIconColor: exportIcon
+          ? window.getComputedStyle(exportIcon).color
+          : ''
+      };
+    });
+    expect(toolbarState).not.toBeNull();
+    expect(toolbarState?.hasHintClass).toBe(true);
+    expect(toolbarState?.hintLabel).toBe('Load as Extension');
+    expect(toolbarState?.hasHintCloseButton).toBe(true);
+    expect(toolbarState?.hasVisibleFloatingHint).toBe(true);
+    expect(toolbarState?.loadButtonIconColor).not.toBe(
+      toolbarState?.exportButtonIconColor
+    );
+
+    const loadResult = await page.evaluate((id: string) => {
+      return window.jupyterapp.commands.execute(id);
+    }, LOAD_COMMAND);
+    expect(loadResult.ok).toBe(true);
+    expect(loadResult.status).toBe('loaded');
+    expect(loadResult.pluginIds).toContain(sharedPluginId);
+
+    await page.waitForCondition(() =>
+      page.evaluate(() => {
+        const current = window.jupyterapp.shell
+          .currentWidget as FileEditorWidget;
+        const root = current?.node as HTMLElement | undefined;
+        const floatingHint = root?.querySelector(
+          '.jp-PluginPlayground-urlLoadedFloatingHint'
+        ) as HTMLElement | null;
+        const hintDisplay = floatingHint
+          ? window.getComputedStyle(floatingHint).display
+          : 'none';
+        return (
+          !!current &&
+          !!root &&
+          !root.classList.contains('jp-PluginPlayground-urlLoadedEditorHint') &&
+          hintDisplay === 'none'
+        );
+      })
+    );
+
     const restoredSource = await page.evaluate(async (path: string) => {
       const fileModel = await window.jupyterapp.serviceManager.contents.get(
         path,
@@ -844,15 +929,14 @@ export default plugin;
       );
       return typeof fileModel.content === 'string' ? fileModel.content : null;
     }, restoredPath);
-    const browserState = await page.evaluate(() => {
+    const browserState = await page.evaluate((toggleCommand: string) => {
       const currentUrl = new URL(window.location.href);
       return {
         pluginQueryParam: currentUrl.searchParams.get('plugin'),
-        hasLoadedToggleCommand: window.jupyterapp.commands.hasCommand(
-          'share-load-command-test:toggle'
-        )
+        hasLoadedToggleCommand:
+          window.jupyterapp.commands.hasCommand(toggleCommand)
       };
-    });
+    }, sharedToggleCommand);
     const hasUntitledFolderWithSameNamedFile = await page.evaluate(async () => {
       const root = await window.jupyterapp.serviceManager.contents.get('', {
         content: true
@@ -899,7 +983,7 @@ export default plugin;
     expect(restoredPath.includes(`/${sourceFilename}`)).toBe(true);
     expect(restoredSource?.trim()).toBe(sharedPluginSource.trim());
     expect(browserState.pluginQueryParam).toBeNull();
-    expect(browserState.hasLoadedToggleCommand).toBe(false);
+    expect(browserState.hasLoadedToggleCommand).toBe(true);
     expect(hasUntitledFolderWithSameNamedFile).toBe(false);
   } finally {
     await page.unrouteAll({ behavior: 'ignoreErrors' });


### PR DESCRIPTION
Closes #161 

This change introduces a small UI hint in the editor to guide users after opening a file from a shared URL, making the next action clearer.