### PR TITLE
Hide Run controls for non-JS/TS files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -390,12 +390,27 @@ class PluginPlayground {
         'Load the active editor file as an extension for plugin development',
       describedBy: { args: null },
       icon: runTileIcon,
-      isEnabled: () =>
-        editorTracker.currentWidget !== null &&
-        editorTracker.currentWidget === app.shell.currentWidget,
+      isEnabled: () => {
+        const currentWidget = editorTracker.currentWidget;
+        if (!currentWidget || currentWidget !== app.shell.currentWidget) {
+          return false;
+        }
+        return this._isSupportedLoadOnSaveFile(
+          ContentUtils.normalizeContentsPath(currentWidget.context.path)
+        );
+      },
+      isVisible: () => {
+        const currentWidget = editorTracker.currentWidget;
+        if (!currentWidget || currentWidget !== app.shell.currentWidget) {
+          return false;
+        }
+        return this._isSupportedLoadOnSaveFile(
+          ContentUtils.normalizeContentsPath(currentWidget.context.path)
+        );
+      },
       execute: async () => {
         const currentWidget = editorTracker.currentWidget;
-        if (currentWidget) {
+        if (currentWidget && currentWidget === app.shell.currentWidget) {
           if (this._sharedFileCueWidgetId === currentWidget.id) {
             this._dismissSharedFileCue?.();
           }
@@ -521,9 +536,18 @@ class PluginPlayground {
             });
           }
         };
+        const onPathChanged = () => {
+          if (app.commands.hasCommand(CommandIDs.loadCurrentAsExtension)) {
+            app.commands.notifyCommandChanged(
+              CommandIDs.loadCurrentAsExtension
+            );
+          }
+        };
         widget.context.saveState.connect(onSaveState);
+        widget.context.pathChanged.connect(onPathChanged);
         widget.disposed.connect(() => {
           widget.context.saveState.disconnect(onSaveState);
+          widget.context.pathChanged.disconnect(onPathChanged);
         });
       }
     );
@@ -831,9 +855,15 @@ class PluginPlayground {
 
       app.shell.currentChanged?.connect(() => {
         tokenSidebar.update();
+        if (app.commands.hasCommand(CommandIDs.loadCurrentAsExtension)) {
+          app.commands.notifyCommandChanged(CommandIDs.loadCurrentAsExtension);
+        }
       });
       editorTracker.currentChanged.connect(() => {
         tokenSidebar.update();
+        if (app.commands.hasCommand(CommandIDs.loadCurrentAsExtension)) {
+          app.commands.notifyCommandChanged(CommandIDs.loadCurrentAsExtension);
+        }
       });
       app.commands.commandChanged.connect((_, args) => {
         if (args.type === 'added' || args.type === 'removed') {
@@ -887,7 +917,7 @@ class PluginPlayground {
   }
 
   private _isSupportedLoadOnSaveFile(path: string): boolean {
-    return /\.(?:[cm]?js|jsx|ts|tsx)$/i.test(path);
+    return /\.(?:js|ts|tsx)$/i.test(path);
   }
 
   private _shouldLoadOnSave(normalizedPath: string): boolean {
@@ -928,27 +958,29 @@ class PluginPlayground {
 
     let currentPath = ContentUtils.normalizeContentsPath(widget.context.path);
     const refresh = () => {
-      if (this._isGlobalLoadOnSaveEnabled()) {
+      currentPath = ContentUtils.normalizeContentsPath(widget.context.path);
+      const isSupported = this._isSupportedLoadOnSaveFile(currentPath);
+      if (this._isGlobalLoadOnSaveEnabled() || !isSupported) {
+        const description = isSupported
+          ? LOAD_ON_SAVE_ENABLED_DESCRIPTION
+          : LOAD_ON_SAVE_DISABLED_DESCRIPTION;
         toggleButton.disabled = true;
         toggleButton.setAttribute('aria-pressed', 'false');
         toggleButton.setAttribute('aria-disabled', 'true');
         toggleNode.classList.add('jp-mod-disabled');
+        toggleButton.title = description;
+        labelButton.title = description;
         toggleWidget.hide();
         return;
       }
       toggleWidget.show();
-      currentPath = ContentUtils.normalizeContentsPath(widget.context.path);
-      const enabled = this._isSupportedLoadOnSaveFile(currentPath);
-      const isPressed = enabled && this._shouldLoadOnSave(currentPath);
-      toggleButton.disabled = !enabled;
+      const isPressed = this._shouldLoadOnSave(currentPath);
+      toggleButton.disabled = false;
       toggleButton.setAttribute('aria-pressed', String(isPressed));
-      toggleButton.setAttribute('aria-disabled', String(!enabled));
-      toggleNode.classList.toggle('jp-mod-disabled', !enabled);
-      const description = enabled
-        ? LOAD_ON_SAVE_ENABLED_DESCRIPTION
-        : LOAD_ON_SAVE_DISABLED_DESCRIPTION;
-      toggleButton.title = description;
-      labelButton.title = description;
+      toggleButton.setAttribute('aria-disabled', 'false');
+      toggleNode.classList.remove('jp-mod-disabled');
+      toggleButton.title = LOAD_ON_SAVE_ENABLED_DESCRIPTION;
+      labelButton.title = LOAD_ON_SAVE_ENABLED_DESCRIPTION;
     };
 
     const onToggleClicked = () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -395,7 +395,7 @@ class PluginPlayground {
         if (!currentWidget || currentWidget !== app.shell.currentWidget) {
           return false;
         }
-        return this._isSupportedLoadOnSaveFile(
+        return this._isSupportedPluginSourceFile(
           ContentUtils.normalizeContentsPath(currentWidget.context.path)
         );
       },
@@ -404,7 +404,7 @@ class PluginPlayground {
         if (!currentWidget || currentWidget !== app.shell.currentWidget) {
           return false;
         }
-        return this._isSupportedLoadOnSaveFile(
+        return this._isSupportedPluginSourceFile(
           ContentUtils.normalizeContentsPath(currentWidget.context.path)
         );
       },
@@ -916,12 +916,12 @@ class PluginPlayground {
     return this.settings.get(LOAD_ON_SAVE_SETTING).composite === true;
   }
 
-  private _isSupportedLoadOnSaveFile(path: string): boolean {
+  private _isSupportedPluginSourceFile(path: string): boolean {
     return /\.(?:js|jsx|ts|tsx)$/i.test(path);
   }
 
   private _shouldLoadOnSave(normalizedPath: string): boolean {
-    if (!this._isSupportedLoadOnSaveFile(normalizedPath)) {
+    if (!this._isSupportedPluginSourceFile(normalizedPath)) {
       return false;
     }
     if (this._isGlobalLoadOnSaveEnabled()) {
@@ -959,7 +959,7 @@ class PluginPlayground {
     let currentPath = ContentUtils.normalizeContentsPath(widget.context.path);
     const refresh = () => {
       currentPath = ContentUtils.normalizeContentsPath(widget.context.path);
-      const isSupported = this._isSupportedLoadOnSaveFile(currentPath);
+      const isSupported = this._isSupportedPluginSourceFile(currentPath);
       if (this._isGlobalLoadOnSaveEnabled() || !isSupported) {
         const description = isSupported
           ? LOAD_ON_SAVE_ENABLED_DESCRIPTION
@@ -987,7 +987,7 @@ class PluginPlayground {
       if (this._isGlobalLoadOnSaveEnabled()) {
         return;
       }
-      if (!this._isSupportedLoadOnSaveFile(currentPath)) {
+      if (!this._isSupportedPluginSourceFile(currentPath)) {
         return;
       }
       if (this._loadOnSaveByFile.has(currentPath)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -917,7 +917,7 @@ class PluginPlayground {
   }
 
   private _isSupportedLoadOnSaveFile(path: string): boolean {
-    return /\.(?:js|ts|tsx)$/i.test(path);
+    return /\.(?:js|jsx|ts|tsx)$/i.test(path);
   }
 
   private _shouldLoadOnSave(normalizedPath: string): boolean {

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -4004,6 +4004,74 @@ test('per-file load-on-save toggle is off by default and enables auto-load', asy
   );
 });
 
+test('hides run controls in non-JS/TS files', async ({ page, tmpPath }) => {
+  const pluginPath = `${tmpPath}/${TEST_FILE}`;
+  const readmePath = `${tmpPath}/README.md`;
+
+  await page.contents.uploadContent(TEST_PLUGIN_SOURCE, 'text', pluginPath);
+  await page.contents.uploadContent(
+    '# Playground\n\nThis is not a runnable plugin source file.\n',
+    'text',
+    readmePath
+  );
+  await page.goto();
+  await page.waitForCondition(() =>
+    page.evaluate((id: string) => {
+      return window.jupyterapp.commands.hasCommand(id);
+    }, LOAD_COMMAND)
+  );
+
+  const getCurrentRunControlsVisibility = async (): Promise<{
+    runVisible: boolean;
+    loadOnSaveVisible: boolean;
+  }> => {
+    return page.evaluate((label: string) => {
+      const isElementVisible = (element: HTMLElement | null): boolean => {
+        if (!element) {
+          return false;
+        }
+        const style = window.getComputedStyle(element);
+        return (
+          style.display !== 'none' &&
+          style.visibility !== 'hidden' &&
+          element.getClientRects().length > 0
+        );
+      };
+      const current = window.jupyterapp.shell.currentWidget as FileEditorWidget;
+      const root = current?.node as HTMLElement | undefined;
+      if (!root) {
+        return { runVisible: false, loadOnSaveVisible: false };
+      }
+      const runItem = root.querySelector(
+        '.jp-Toolbar > .jp-Toolbar-item[data-jp-item-name="load-as-extension"]'
+      ) as HTMLElement | null;
+      const loadOnSaveButton = root.querySelector(
+        `button[aria-label="${label}"]`
+      ) as HTMLElement | null;
+      return {
+        runVisible: isElementVisible(runItem),
+        loadOnSaveVisible: isElementVisible(loadOnSaveButton)
+      };
+    }, LOAD_ON_SAVE_CHECKBOX_LABEL);
+  };
+
+  await page.filebrowser.open(pluginPath);
+  expect(await page.activity.activateTab(TEST_FILE)).toBe(true);
+  await expect
+    .poll(async () => {
+      return getCurrentRunControlsVisibility();
+    })
+    .toEqual({ runVisible: true, loadOnSaveVisible: true });
+
+  await page.filebrowser.open(readmePath);
+  expect(await page.activity.activateTab('README.md')).toBe(true);
+  await expect
+    .poll(async () => {
+      return getCurrentRunControlsVisibility();
+    })
+    .toEqual({ runVisible: false, loadOnSaveVisible: false });
+});
+
 test.describe('load-on-save setting', () => {
   test.use({
     mockSettings: {


### PR DESCRIPTION
Fixes #199 

This PR makes the extension controls(run extension and run on save) available only for `.js`, `jsx`, `.ts`, and `.tsx` files.