### PR TITLE
Support hide URL params for shared-link layout

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1112,53 +1112,31 @@ class PluginPlayground {
       return;
     }
 
-    if (this.app.hasPlugin(NOTEBOOK_SHELL_PLUGIN_ID)) {
-      const notebookShell = this.app.shell as unknown as {
-        leftCollapsed: boolean;
-        rightCollapsed: boolean;
-        collapseLeft: () => void;
-        collapseRight: () => void;
-        collapseTop: () => void;
-      };
-      if (!notebookShell.leftCollapsed) {
-        notebookShell.collapseLeft();
+    const runCommand = async (command: string, args?: any): Promise<void> => {
+      if (!this.app.commands.hasCommand(command)) {
+        return;
       }
-      if (!notebookShell.rightCollapsed) {
-        notebookShell.collapseRight();
+      if (args) {
+        await this.app.commands.execute(command, args);
+      } else {
+        await this.app.commands.execute(command);
       }
-      notebookShell.collapseTop();
-      return;
-    }
-
-    const labShell = this.app.shell as unknown as {
-      mode: 'single-document' | 'multiple-document';
-      leftCollapsed: boolean;
-      rightCollapsed: boolean;
-      collapseLeft: () => void;
-      collapseRight: () => void;
-      isTopInSimpleModeVisible: () => boolean;
-      toggleTopInSimpleModeVisibility: () => void;
     };
 
-    if (labShell.mode !== 'single-document') {
-      labShell.mode = 'single-document';
-    }
-    if (!labShell.leftCollapsed) {
-      labShell.collapseLeft();
-    }
-    if (!labShell.rightCollapsed) {
-      labShell.collapseRight();
-    }
-    if (labShell.isTopInSimpleModeVisible()) {
-      labShell.toggleTopInSimpleModeVisibility();
-    }
+    const hideArea = async (command: string): Promise<void> => {
+      if (!this.app.commands.hasCommand(command)) {
+        return;
+      }
+      if (this.app.commands.isToggled(command)) {
+        await this.app.commands.execute(command);
+      }
+    };
 
-    if (
-      this.app.commands.hasCommand('statusbar:toggle') &&
-      this.app.commands.isToggled('statusbar:toggle')
-    ) {
-      await this.app.commands.execute('statusbar:toggle');
-    }
+    await runCommand('application:set-mode', { mode: 'single-document' });
+    await hideArea('application:toggle-left-area');
+    await hideArea('application:toggle-right-area');
+    await hideArea('application:toggle-header');
+    await hideArea('statusbar:toggle');
   }
 
   private _isHideAllQueryEnabled(url: string): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -792,6 +792,9 @@ class PluginPlayground {
     });
 
     app.restored.then(async () => {
+      this._hideAllFromInitialUrl =
+        typeof window !== 'undefined' &&
+        this._isHideAllQueryEnabled(window.location.href);
       const settings = this.settings;
       this._updateSettings(requirejs, settings);
       this._refreshExtensionPoints();
@@ -1138,8 +1141,9 @@ class PluginPlayground {
 
   private async _applyLayoutFromQuery(): Promise<void> {
     const shouldHideAll =
-      typeof window !== 'undefined' &&
-      this._isHideAllQueryEnabled(window.location.href);
+      this._hideAllFromInitialUrl ||
+      (typeof window !== 'undefined' &&
+        this._isHideAllQueryEnabled(window.location.href));
     if (!shouldHideAll) {
       return;
     }
@@ -1155,20 +1159,56 @@ class PluginPlayground {
       }
     };
 
-    const hideArea = async (command: string): Promise<void> => {
+    const shell = this.app.shell as any;
+
+    const hideArea = async (
+      command: string,
+      collapsedState: boolean | null
+    ): Promise<void> => {
       if (!this.app.commands.hasCommand(command)) {
         return;
       }
-      if (this.app.commands.isToggled(command)) {
-        await this.app.commands.execute(command);
+      if (collapsedState !== null) {
+        if (!collapsedState) {
+          await this.app.commands.execute(command);
+        }
+        return;
       }
+      await this.app.commands.execute(command);
     };
 
     await runCommand('application:set-mode', { mode: 'single-document' });
-    await hideArea('application:toggle-left-area');
-    await hideArea('application:toggle-right-area');
-    await hideArea('application:toggle-header');
-    await hideArea('statusbar:toggle');
+    if (typeof shell.collapseLeft === 'function') {
+      shell.collapseLeft();
+    } else {
+      await hideArea(
+        'application:toggle-left-area',
+        typeof shell.leftCollapsed === 'boolean' ? shell.leftCollapsed : null
+      );
+    }
+    if (typeof shell.collapseRight === 'function') {
+      shell.collapseRight();
+    } else {
+      await hideArea(
+        'application:toggle-right-area',
+        typeof shell.rightCollapsed === 'boolean' ? shell.rightCollapsed : null
+      );
+    }
+
+    if (typeof shell.isTopInSimpleModeVisible === 'function') {
+      if (shell.isTopInSimpleModeVisible()) {
+        await runCommand('application:toggle-header');
+      }
+    } else {
+      await hideArea('application:toggle-header', null);
+    }
+
+    if (
+      this.app.commands.hasCommand('statusbar:toggle') &&
+      this.app.commands.isToggled('statusbar:toggle')
+    ) {
+      await this.app.commands.execute('statusbar:toggle');
+    }
   }
 
   private _isHideAllQueryEnabled(url: string): boolean {
@@ -3139,6 +3179,7 @@ class PluginPlayground {
   private readonly _loadOnSaveToggleRefreshers = new Set<() => void>();
   private _sharedFileCueWidgetId: string | null = null;
   private _dismissSharedFileCue: (() => void) | null = null;
+  private _hideAllFromInitialUrl = false;
   private readonly _tokenMap = new Map<string, Token<string>>();
   private readonly _tokenDescriptionMap = new Map<string, string>();
   private readonly _documentationWidgets = new Map<

--- a/src/index.ts
+++ b/src/index.ts
@@ -323,6 +323,7 @@ const ARCHIVE_EXCLUDED_DIRECTORIES = new Set([
   'node_modules'
 ]);
 const ARCHIVE_FILE_READ_CONCURRENCY = 8;
+const HIDE_ALL_QUERY_KEY = 'hide-all';
 const URL_LOADED_EDITOR_HINT_CLASS = 'jp-PluginPlayground-urlLoadedEditorHint';
 const URL_LOADED_EDITOR_HINT_TITLE = 'Load as Extension';
 const URL_LOADED_EDITOR_HINT_MESSAGE =
@@ -868,6 +869,7 @@ class PluginPlayground {
         await this._loadPlugin(t, null);
       }
       await this._shareViaLinkController.loadSharedPluginFromUrl();
+      await this._applyLayoutFromQuery();
 
       settings.changed.connect(updatedSettings => {
         this.settings = updatedSettings;
@@ -1100,6 +1102,81 @@ class PluginPlayground {
     };
     widget.context.pathChanged.connect(onPathChanged);
     widget.disposed.connect(disposeCue);
+  }
+
+  private async _applyLayoutFromQuery(): Promise<void> {
+    const shouldHideAll =
+      typeof window !== 'undefined' &&
+      this._isHideAllQueryEnabled(window.location.href);
+    if (!shouldHideAll) {
+      return;
+    }
+
+    if (this.app.hasPlugin(NOTEBOOK_SHELL_PLUGIN_ID)) {
+      const notebookShell = this.app.shell as unknown as {
+        leftCollapsed: boolean;
+        rightCollapsed: boolean;
+        collapseLeft: () => void;
+        collapseRight: () => void;
+        collapseTop: () => void;
+      };
+      if (!notebookShell.leftCollapsed) {
+        notebookShell.collapseLeft();
+      }
+      if (!notebookShell.rightCollapsed) {
+        notebookShell.collapseRight();
+      }
+      notebookShell.collapseTop();
+      return;
+    }
+
+    const labShell = this.app.shell as unknown as {
+      mode: 'single-document' | 'multiple-document';
+      leftCollapsed: boolean;
+      rightCollapsed: boolean;
+      collapseLeft: () => void;
+      collapseRight: () => void;
+      isTopInSimpleModeVisible: () => boolean;
+      toggleTopInSimpleModeVisibility: () => void;
+    };
+
+    if (labShell.mode !== 'single-document') {
+      labShell.mode = 'single-document';
+    }
+    if (!labShell.leftCollapsed) {
+      labShell.collapseLeft();
+    }
+    if (!labShell.rightCollapsed) {
+      labShell.collapseRight();
+    }
+    if (labShell.isTopInSimpleModeVisible()) {
+      labShell.toggleTopInSimpleModeVisibility();
+    }
+
+    if (
+      this.app.commands.hasCommand('statusbar:toggle') &&
+      this.app.commands.isToggled('statusbar:toggle')
+    ) {
+      await this.app.commands.execute('statusbar:toggle');
+    }
+  }
+
+  private _isHideAllQueryEnabled(url: string): boolean {
+    const isTrue = (value: string | null): boolean =>
+      (value ?? '').trim().toLowerCase() === 'true';
+
+    try {
+      const parsedUrl = new URL(url);
+      if (isTrue(parsedUrl.searchParams.get(HIDE_ALL_QUERY_KEY))) {
+        return true;
+      }
+
+      const hashQuery = parsedUrl.hash.replace(/^#/, '').replace(/^\?/, '');
+      const hashParams = new URLSearchParams(hashQuery);
+      return isTrue(hashParams.get(HIDE_ALL_QUERY_KEY));
+    } catch {
+      return false;
+    }
   }
 
   private _queuePluginLoad(

--- a/src/index.ts
+++ b/src/index.ts
@@ -184,6 +184,12 @@ interface IResolvedExportContext {
   usedTemplate: boolean;
 }
 
+interface ILayoutHideSelection {
+  hideAll: boolean;
+  hideMenu: boolean;
+  hideStatusBar: boolean;
+}
+
 const PLUGIN_TEMPLATE = `import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin,
@@ -323,7 +329,15 @@ const ARCHIVE_EXCLUDED_DIRECTORIES = new Set([
   'node_modules'
 ]);
 const ARCHIVE_FILE_READ_CONCURRENCY = 8;
-const HIDE_ALL_QUERY_KEY = 'hide-all';
+const HIDE_QUERY_KEY = 'hide';
+const HIDE_QUERY_VALUE_ALL = 'all';
+const HIDE_QUERY_VALUE_MENU = 'menu';
+const HIDE_QUERY_VALUE_STATUSBAR = 'statusbar';
+const EMPTY_LAYOUT_HIDE_SELECTION: ILayoutHideSelection = {
+  hideAll: false,
+  hideMenu: false,
+  hideStatusBar: false
+};
 const URL_LOADED_EDITOR_HINT_CLASS = 'jp-PluginPlayground-urlLoadedEditorHint';
 const URL_LOADED_EDITOR_HINT_TITLE = 'Load as Extension';
 const URL_LOADED_EDITOR_HINT_MESSAGE =
@@ -365,9 +379,10 @@ class PluginPlayground {
     protected logConsoleTracker: ILogConsoleTracker | null
   ) {
     registerCoreKnownModules();
-    this._hideAllFromInitialUrl =
-      typeof window !== 'undefined' &&
-      this._isHideAllQueryEnabled(window.location.href);
+    this._layoutHideFromInitialUrl =
+      typeof window !== 'undefined'
+        ? this._layoutHideSelectionFromUrl(window.location.href)
+        : EMPTY_LAYOUT_HIDE_SELECTION;
 
     this._shareViaLinkController = new ShareViaLinkController({
       app: this.app,
@@ -1140,11 +1155,28 @@ class PluginPlayground {
   }
 
   private async _applyLayoutFromQuery(): Promise<void> {
-    const shouldHideAll =
-      this._hideAllFromInitialUrl ||
-      (typeof window !== 'undefined' &&
-        this._isHideAllQueryEnabled(window.location.href));
-    if (!shouldHideAll) {
+    const querySelection =
+      typeof window !== 'undefined'
+        ? this._layoutHideSelectionFromUrl(window.location.href)
+        : EMPTY_LAYOUT_HIDE_SELECTION;
+    const hideSelection: ILayoutHideSelection = {
+      hideAll: this._layoutHideFromInitialUrl.hideAll || querySelection.hideAll,
+      hideMenu:
+        this._layoutHideFromInitialUrl.hideMenu || querySelection.hideMenu,
+      hideStatusBar:
+        this._layoutHideFromInitialUrl.hideStatusBar ||
+        querySelection.hideStatusBar
+    };
+    if (hideSelection.hideAll) {
+      hideSelection.hideMenu = true;
+      hideSelection.hideStatusBar = true;
+    }
+
+    if (
+      !hideSelection.hideAll &&
+      !hideSelection.hideMenu &&
+      !hideSelection.hideStatusBar
+    ) {
       return;
     }
 
@@ -1152,7 +1184,7 @@ class PluginPlayground {
       if (!this.app.commands.hasCommand(command)) {
         return;
       }
-      if (args) {
+      if (args !== undefined) {
         await this.app.commands.execute(command, args);
       } else {
         await this.app.commands.execute(command);
@@ -1165,17 +1197,50 @@ class PluginPlayground {
       command: string,
       collapsedState: boolean | null
     ): Promise<void> => {
-      if (!this.app.commands.hasCommand(command)) {
-        return;
-      }
       if (collapsedState !== null) {
         if (!collapsedState) {
-          await this.app.commands.execute(command);
+          await runCommand(command);
         }
         return;
       }
-      await this.app.commands.execute(command);
+      await runCommand(command);
     };
+
+    const hideMenu = async (
+      ensureSingleDocumentMode: boolean
+    ): Promise<void> => {
+      if (ensureSingleDocumentMode) {
+        await runCommand('application:set-mode', { mode: 'single-document' });
+      }
+      if (typeof shell.isTopInSimpleModeVisible === 'function') {
+        if (shell.isTopInSimpleModeVisible()) {
+          await runCommand('application:toggle-header');
+        }
+        return;
+      }
+      await runCommand('application:toggle-header');
+    };
+
+    const hideStatusBar = async (): Promise<void> => {
+      try {
+        if (!this.app.commands.isToggled('statusbar:toggle')) {
+          return;
+        }
+        await runCommand('statusbar:toggle');
+      } catch {
+        return;
+      }
+    };
+
+    if (!hideSelection.hideAll) {
+      if (hideSelection.hideMenu) {
+        await hideMenu(true);
+      }
+      if (hideSelection.hideStatusBar) {
+        await hideStatusBar();
+      }
+      return;
+    }
 
     await runCommand('application:set-mode', { mode: 'single-document' });
     if (typeof shell.collapseLeft === 'function') {
@@ -1195,37 +1260,55 @@ class PluginPlayground {
       );
     }
 
-    if (typeof shell.isTopInSimpleModeVisible === 'function') {
-      if (shell.isTopInSimpleModeVisible()) {
-        await runCommand('application:toggle-header');
-      }
-    } else {
-      await hideArea('application:toggle-header', null);
-    }
-
-    if (
-      this.app.commands.hasCommand('statusbar:toggle') &&
-      this.app.commands.isToggled('statusbar:toggle')
-    ) {
-      await this.app.commands.execute('statusbar:toggle');
-    }
+    await hideMenu(false);
+    await hideStatusBar();
   }
 
-  private _isHideAllQueryEnabled(url: string): boolean {
-    const isTrue = (value: string | null): boolean =>
-      (value ?? '').trim().toLowerCase() === 'true';
+  private _layoutHideSelectionFromUrl(url: string): ILayoutHideSelection {
+    const selection: ILayoutHideSelection = {
+      hideAll: false,
+      hideMenu: false,
+      hideStatusBar: false
+    };
+    const applyParams = (params: URLSearchParams): void => {
+      for (const hideValue of params.getAll(HIDE_QUERY_KEY)) {
+        const values = hideValue.split(',');
+        for (const rawValue of values) {
+          const value = rawValue.trim().toLowerCase();
+          if (value === HIDE_QUERY_VALUE_ALL) {
+            selection.hideAll = true;
+          } else if (value === HIDE_QUERY_VALUE_MENU) {
+            selection.hideMenu = true;
+          } else if (value === HIDE_QUERY_VALUE_STATUSBAR) {
+            selection.hideStatusBar = true;
+          }
+        }
+      }
+    };
 
     try {
       const parsedUrl = new URL(url);
-      if (isTrue(parsedUrl.searchParams.get(HIDE_ALL_QUERY_KEY))) {
-        return true;
+      applyParams(parsedUrl.searchParams);
+
+      const trimmedHash = parsedUrl.hash.startsWith('#')
+        ? parsedUrl.hash.slice(1)
+        : parsedUrl.hash;
+      if (trimmedHash) {
+        const queryLike = trimmedHash.startsWith('?')
+          ? trimmedHash.slice(1)
+          : trimmedHash;
+        if (queryLike.includes('=')) {
+          applyParams(new URLSearchParams(queryLike));
+        }
       }
 
-      const hashQuery = parsedUrl.hash.replace(/^#/, '').replace(/^\?/, '');
-      const hashParams = new URLSearchParams(hashQuery);
-      return isTrue(hashParams.get(HIDE_ALL_QUERY_KEY));
+      if (selection.hideAll) {
+        selection.hideMenu = true;
+        selection.hideStatusBar = true;
+      }
+      return selection;
     } catch {
-      return false;
+      return EMPTY_LAYOUT_HIDE_SELECTION;
     }
   }
 
@@ -3179,7 +3262,7 @@ class PluginPlayground {
   private readonly _loadOnSaveToggleRefreshers = new Set<() => void>();
   private _sharedFileCueWidgetId: string | null = null;
   private _dismissSharedFileCue: (() => void) | null = null;
-  private _hideAllFromInitialUrl = false;
+  private readonly _layoutHideFromInitialUrl: ILayoutHideSelection;
   private readonly _tokenMap = new Map<string, Token<string>>();
   private readonly _tokenDescriptionMap = new Map<string, string>();
   private readonly _documentationWidgets = new Map<

--- a/src/index.ts
+++ b/src/index.ts
@@ -365,6 +365,9 @@ class PluginPlayground {
     protected logConsoleTracker: ILogConsoleTracker | null
   ) {
     registerCoreKnownModules();
+    this._hideAllFromInitialUrl =
+      typeof window !== 'undefined' &&
+      this._isHideAllQueryEnabled(window.location.href);
 
     this._shareViaLinkController = new ShareViaLinkController({
       app: this.app,
@@ -792,9 +795,6 @@ class PluginPlayground {
     });
 
     app.restored.then(async () => {
-      this._hideAllFromInitialUrl =
-        typeof window !== 'undefined' &&
-        this._isHideAllQueryEnabled(window.location.href);
       const settings = this.settings;
       this._updateSettings(requirejs, settings);
       this._refreshExtensionPoints();

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -2217,14 +2217,17 @@ export default plugin;
   }
 });
 
-test('applies hide-all layout from shared URL', async ({ page, tmpPath }) => {
-  const projectRoot = `${tmpPath}/share-hide-all-layout-test`;
-  const sourceFilename = 'share-hide-all-entry.ts';
+test('applies hide=all layout from shared URL hash params', async ({
+  page,
+  tmpPath
+}) => {
+  const projectRoot = `${tmpPath}/share-hide-all-hash-layout-test`;
+  const sourceFilename = 'share-hide-all-hash-entry.ts';
   const sourcePath = `${projectRoot}/src/${sourceFilename}`;
   const packageJsonPath = `${projectRoot}/package.json`;
   const sharedPluginSource = `
 const plugin = {
-  id: 'share-hide-all-layout-test:plugin',
+  id: 'share-hide-all-hash-layout-test:plugin',
   autoStart: true,
   activate: () => undefined
 };
@@ -2235,7 +2238,7 @@ export default plugin;
   await page.contents.uploadContent(
     JSON.stringify(
       {
-        name: 'share-hide-all-layout-test',
+        name: 'share-hide-all-hash-layout-test',
         version: '0.1.0',
         jupyterlab: { extension: true }
       },
@@ -2264,16 +2267,19 @@ export default plugin;
   expect(shareResult.ok).toBe(true);
   expect(typeof shareResult.link).toBe('string');
 
-  const hideAllSharedLink = await page.evaluate((link: string) => {
+  const hideAllInHashSharedLink = await page.evaluate((link: string) => {
     const url = new URL(link);
     url.searchParams.set('z', '1');
-    url.searchParams.set('hide-all', 'true');
+    const hashQuery = url.hash.startsWith('#') ? url.hash.slice(1) : url.hash;
+    const hashParams = new URLSearchParams(hashQuery);
+    hashParams.set('hide', 'all');
+    url.hash = hashParams.toString();
     return url.toString();
   }, shareResult.link);
 
   await page.evaluate((url: string) => {
     window.location.assign(url);
-  }, hideAllSharedLink);
+  }, hideAllInHashSharedLink);
 
   await page.waitForCondition(async () => {
     try {
@@ -2314,6 +2320,108 @@ export default plugin;
           : true;
 
         return shell.mode === 'single-document' && topHidden && statusbarHidden;
+      }, sourceFilename);
+    } catch {
+      return false;
+    }
+  });
+});
+
+test('applies repeated hide query values from shared URL', async ({
+  page,
+  tmpPath
+}) => {
+  const projectRoot = `${tmpPath}/share-hide-query-layout-test`;
+  const sourceFilename = 'share-hide-query-entry.ts';
+  const sourcePath = `${projectRoot}/src/${sourceFilename}`;
+  const packageJsonPath = `${projectRoot}/package.json`;
+  const sharedPluginSource = `
+const plugin = {
+  id: 'share-hide-query-layout-test:plugin',
+  autoStart: true,
+  activate: () => undefined
+};
+
+export default plugin;
+`;
+
+  await page.contents.uploadContent(
+    JSON.stringify(
+      {
+        name: 'share-hide-query-layout-test',
+        version: '0.1.0',
+        jupyterlab: { extension: true }
+      },
+      null,
+      2
+    ),
+    'text',
+    packageJsonPath
+  );
+  await page.contents.uploadContent(sharedPluginSource, 'text', sourcePath);
+  await page.goto();
+
+  await page.filebrowser.open(sourcePath);
+  expect(await page.activity.activateTab(sourceFilename)).toBe(true);
+
+  await page.waitForCondition(() =>
+    page.evaluate(
+      (id: string) => window.jupyterapp.commands.hasCommand(id),
+      SHARE_COMMAND
+    )
+  );
+
+  const shareResult = await page.evaluate((id: string) => {
+    return window.jupyterapp.commands.execute(id);
+  }, SHARE_COMMAND);
+  expect(shareResult.ok).toBe(true);
+  expect(typeof shareResult.link).toBe('string');
+
+  const hideValuesSharedLink = await page.evaluate((link: string) => {
+    const url = new URL(link);
+    url.searchParams.set('z', '1');
+    url.searchParams.append('hide', 'statusbar');
+    url.searchParams.append('hide', 'menu');
+    return url.toString();
+  }, shareResult.link);
+
+  await page.evaluate((url: string) => {
+    window.location.assign(url);
+  }, hideValuesSharedLink);
+
+  await page.waitForCondition(async () => {
+    try {
+      return await page.evaluate((sharedFileName: string) => {
+        const app = window.jupyterapp as any;
+        if (!app) {
+          return false;
+        }
+        const shell = app.shell as any;
+        const currentPath = shell.currentWidget?.context?.path ?? '';
+        const openedSharedFile =
+          typeof currentPath === 'string' &&
+          currentPath.includes('plugin-playground-shared/') &&
+          currentPath.endsWith(`/${sharedFileName}`);
+        if (!openedSharedFile) {
+          return false;
+        }
+
+        const isNotebookHost = app.hasPlugin(
+          '@jupyter-notebook/application-extension:shell'
+        );
+        if (isNotebookHost) {
+          return true;
+        }
+
+        const topHidden =
+          typeof shell.isTopInSimpleModeVisible === 'function'
+            ? shell.isTopInSimpleModeVisible() === false
+            : true;
+        const statusbarHidden = app.commands.hasCommand('statusbar:toggle')
+          ? app.commands.isToggled('statusbar:toggle') === false
+          : true;
+
+        return topHidden && statusbarHidden;
       }, sourceFilename);
     } catch {
       return false;

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -2217,6 +2217,110 @@ export default plugin;
   }
 });
 
+test('applies hide-all layout from shared URL', async ({ page, tmpPath }) => {
+  const projectRoot = `${tmpPath}/share-hide-all-layout-test`;
+  const sourceFilename = 'share-hide-all-entry.ts';
+  const sourcePath = `${projectRoot}/src/${sourceFilename}`;
+  const packageJsonPath = `${projectRoot}/package.json`;
+  const sharedPluginSource = `
+const plugin = {
+  id: 'share-hide-all-layout-test:plugin',
+  autoStart: true,
+  activate: () => undefined
+};
+
+export default plugin;
+`;
+
+  await page.contents.uploadContent(
+    JSON.stringify(
+      {
+        name: 'share-hide-all-layout-test',
+        version: '0.1.0',
+        jupyterlab: { extension: true }
+      },
+      null,
+      2
+    ),
+    'text',
+    packageJsonPath
+  );
+  await page.contents.uploadContent(sharedPluginSource, 'text', sourcePath);
+  await page.goto();
+
+  await page.filebrowser.open(sourcePath);
+  expect(await page.activity.activateTab(sourceFilename)).toBe(true);
+
+  await page.waitForCondition(() =>
+    page.evaluate(
+      (id: string) => window.jupyterapp.commands.hasCommand(id),
+      SHARE_COMMAND
+    )
+  );
+
+  const shareResult = await page.evaluate((id: string) => {
+    return window.jupyterapp.commands.execute(id);
+  }, SHARE_COMMAND);
+  expect(shareResult.ok).toBe(true);
+  expect(typeof shareResult.link).toBe('string');
+
+  const hideAllSharedLink = await page.evaluate((link: string) => {
+    const url = new URL(link);
+    url.searchParams.set('z', '1');
+    url.searchParams.set('hide-all', 'true');
+    return url.toString();
+  }, shareResult.link);
+
+  await page.evaluate((url: string) => {
+    window.location.assign(url);
+  }, hideAllSharedLink);
+
+  await page.waitForCondition(async () => {
+    try {
+      return await page.evaluate((sharedFileName: string) => {
+        const app = window.jupyterapp as any;
+        if (!app) {
+          return false;
+        }
+        const shell = app.shell as any;
+        const currentPath = shell.currentWidget?.context?.path ?? '';
+        const openedSharedFile =
+          typeof currentPath === 'string' &&
+          currentPath.includes('plugin-playground-shared/') &&
+          currentPath.endsWith(`/${sharedFileName}`);
+        if (!openedSharedFile) {
+          return false;
+        }
+
+        const leftCollapsed = shell.leftCollapsed === true;
+        const rightCollapsed = shell.rightCollapsed === true;
+        if (!leftCollapsed || !rightCollapsed) {
+          return false;
+        }
+
+        const isNotebookHost = app.hasPlugin(
+          '@jupyter-notebook/application-extension:shell'
+        );
+        if (isNotebookHost) {
+          return true;
+        }
+
+        const topHidden =
+          typeof shell.isTopInSimpleModeVisible === 'function'
+            ? shell.isTopInSimpleModeVisible() === false
+            : true;
+        const statusbarHidden = app.commands.hasCommand('statusbar:toggle')
+          ? app.commands.isToggled('statusbar:toggle') === false
+          : true;
+
+        return shell.mode === 'single-document' && topHidden && statusbarHidden;
+      }, sourceFilename);
+    } catch {
+      return false;
+    }
+  });
+});
+
 test('shares selected file or folder when using browser selection', async ({
   page,
   tmpPath


### PR DESCRIPTION
Ref: https://github.com/jupyterlab/jupyterlab/pull/18726#discussion_r3130455039

This PR adds a single hide parameter and keeps layout behavior deterministic. Shared links now support `hide=all` and granular controls via repeated/comma-separated values such as `hide=menu&hide=statusbar`, parsed from both search and hash params.