### PR TITLE
Fix missing Run button after refresh

### DIFF
--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -74,8 +74,6 @@
     "Editor": [
       {
         "name": "load-as-extension",
-        "command": "plugin-playground:load-as-extension",
-        "label": "Run",
         "rank": 20
       },
       { "name": "plugin-playground-load-on-save", "rank": 21 },

--- a/src/index.ts
+++ b/src/index.ts
@@ -392,7 +392,7 @@ class PluginPlayground {
       icon: runTileIcon,
       isEnabled: () => {
         const currentWidget = editorTracker.currentWidget;
-        if (!currentWidget || currentWidget !== app.shell.currentWidget) {
+        if (!currentWidget) {
           return false;
         }
         return this._isSupportedPluginSourceFile(
@@ -401,7 +401,7 @@ class PluginPlayground {
       },
       isVisible: () => {
         const currentWidget = editorTracker.currentWidget;
-        if (!currentWidget || currentWidget !== app.shell.currentWidget) {
+        if (!currentWidget) {
           return false;
         }
         return this._isSupportedPluginSourceFile(
@@ -410,7 +410,7 @@ class PluginPlayground {
       },
       execute: async () => {
         const currentWidget = editorTracker.currentWidget;
-        if (currentWidget && currentWidget === app.shell.currentWidget) {
+        if (currentWidget) {
           if (this._sharedFileCueWidgetId === currentWidget.id) {
             this._dismissSharedFileCue?.();
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,8 @@ import {
   showDialog,
   showErrorMessage,
   ICommandPalette,
-  IToolbarWidgetRegistry
+  IToolbarWidgetRegistry,
+  ToolbarButton
 } from '@jupyterlab/apputils';
 
 import { ILogConsoleTracker } from 'jupyterlab-js-logs';
@@ -287,6 +288,7 @@ const CREATE_PLUGIN_FROM_NOTEBOOK_TREE_ARGS_SCHEMA = {
     }
   }
 };
+const LOAD_AS_EXTENSION_TOOLBAR_ITEM = 'load-as-extension';
 const LOAD_ON_SAVE_TOGGLE_TOOLBAR_ITEM = 'plugin-playground-load-on-save';
 const LOAD_ON_SAVE_CHECKBOX_LABEL = 'Run on save';
 const LOAD_ON_SAVE_SETTING = 'loadOnSave';
@@ -392,7 +394,7 @@ class PluginPlayground {
       icon: args => (args['isPalette'] ? undefined : runTileIcon),
       isEnabled: () => {
         const currentWidget = editorTracker.currentWidget;
-        if (!currentWidget) {
+        if (!currentWidget || currentWidget !== app.shell.currentWidget) {
           return false;
         }
         return this._isSupportedPluginSourceFile(
@@ -401,7 +403,7 @@ class PluginPlayground {
       },
       isVisible: () => {
         const currentWidget = editorTracker.currentWidget;
-        if (!currentWidget) {
+        if (!currentWidget || currentWidget !== app.shell.currentWidget) {
           return false;
         }
         return this._isSupportedPluginSourceFile(
@@ -410,7 +412,7 @@ class PluginPlayground {
       },
       execute: async () => {
         const currentWidget = editorTracker.currentWidget;
-        if (currentWidget) {
+        if (currentWidget && currentWidget === app.shell.currentWidget) {
           if (this._sharedFileCueWidgetId === currentWidget.id) {
             this._dismissSharedFileCue?.();
           }
@@ -427,8 +429,6 @@ class PluginPlayground {
         } as IPluginLoadResult;
       }
     });
-
-    this._notifyLoadCurrentAsExtensionCommandChanged();
 
     app.commands.addCommand(CommandIDs.exportAsExtension, {
       label: 'Export Plugin Folder As Extension',
@@ -502,6 +502,12 @@ class PluginPlayground {
 
     toolbarWidgetRegistry.addFactory<IDocumentWidget<FileEditor>>(
       'Editor',
+      LOAD_AS_EXTENSION_TOOLBAR_ITEM,
+      widget => this._createLoadAsExtensionToolbarWidget(widget)
+    );
+
+    toolbarWidgetRegistry.addFactory<IDocumentWidget<FileEditor>>(
+      'Editor',
       LOAD_ON_SAVE_TOGGLE_TOOLBAR_ITEM,
       widget => this._createLoadOnSaveToggleWidget(widget)
     );
@@ -539,14 +545,9 @@ class PluginPlayground {
             });
           }
         };
-        const onPathChanged = () => {
-          this._notifyLoadCurrentAsExtensionCommandChanged();
-        };
         widget.context.saveState.connect(onSaveState);
-        widget.context.pathChanged.connect(onPathChanged);
         widget.disposed.connect(() => {
           widget.context.saveState.disconnect(onSaveState);
-          widget.context.pathChanged.disconnect(onPathChanged);
         });
       }
     );
@@ -861,15 +862,11 @@ class PluginPlayground {
         }
       }
 
-      this._notifyLoadCurrentAsExtensionCommandChanged();
-
       app.shell.currentChanged?.connect(() => {
         tokenSidebar.update();
-        this._notifyLoadCurrentAsExtensionCommandChanged();
       });
       editorTracker.currentChanged.connect(() => {
         tokenSidebar.update();
-        this._notifyLoadCurrentAsExtensionCommandChanged();
       });
       app.commands.commandChanged.connect((_, args) => {
         if (args.type === 'added' || args.type === 'removed') {
@@ -922,12 +919,6 @@ class PluginPlayground {
     return this.settings.get(LOAD_ON_SAVE_SETTING).composite === true;
   }
 
-  private _notifyLoadCurrentAsExtensionCommandChanged(): void {
-    if (this.app.commands.hasCommand(CommandIDs.loadCurrentAsExtension)) {
-      this.app.commands.notifyCommandChanged(CommandIDs.loadCurrentAsExtension);
-    }
-  }
-
   private _isSupportedPluginSourceFile(path: string): boolean {
     return /\.(?:js|jsx|ts|tsx)$/i.test(path);
   }
@@ -940,6 +931,60 @@ class PluginPlayground {
       return true;
     }
     return this._loadOnSaveByFile.has(normalizedPath);
+  }
+
+  private _createLoadAsExtensionToolbarWidget(
+    widget: IDocumentWidget<FileEditor>
+  ): Widget {
+    const runButton = new ToolbarButton({
+      label: 'Run',
+      icon: runTileIcon,
+      tooltip:
+        'Load the active editor file as an extension for plugin development',
+      dataset: {
+        command: CommandIDs.loadCurrentAsExtension
+      },
+      noFocusOnClick: true,
+      onClick: () => {
+        const normalizedPath = ContentUtils.normalizeContentsPath(
+          widget.context.path
+        );
+        if (!this._isSupportedPluginSourceFile(normalizedPath)) {
+          return;
+        }
+        if (this._sharedFileCueWidgetId === widget.id) {
+          this._dismissSharedFileCue?.();
+        }
+        void this._queuePluginLoad(
+          widget.context.model.toString(),
+          widget.context.path
+        );
+      }
+    });
+
+    const refresh = () => {
+      const normalizedPath = ContentUtils.normalizeContentsPath(
+        widget.context.path
+      );
+      runButton.setHidden(!this._isSupportedPluginSourceFile(normalizedPath));
+    };
+
+    widget.context.pathChanged.connect(refresh);
+    refresh();
+
+    let isDisposed = false;
+    const dispose = () => {
+      if (isDisposed) {
+        return;
+      }
+      isDisposed = true;
+      widget.context.pathChanged.disconnect(refresh);
+    };
+
+    runButton.disposed.connect(dispose);
+    widget.disposed.connect(dispose);
+
+    return runButton;
   }
 
   private _createLoadOnSaveToggleWidget(

--- a/src/index.ts
+++ b/src/index.ts
@@ -428,7 +428,7 @@ class PluginPlayground {
       }
     });
 
-    app.commands.notifyCommandChanged(CommandIDs.loadCurrentAsExtension);
+    this._notifyLoadCurrentAsExtensionCommandChanged();
 
     app.commands.addCommand(CommandIDs.exportAsExtension, {
       label: 'Export Plugin Folder As Extension',
@@ -539,11 +539,7 @@ class PluginPlayground {
           }
         };
         const onPathChanged = () => {
-          if (app.commands.hasCommand(CommandIDs.loadCurrentAsExtension)) {
-            app.commands.notifyCommandChanged(
-              CommandIDs.loadCurrentAsExtension
-            );
-          }
+          this._notifyLoadCurrentAsExtensionCommandChanged();
         };
         widget.context.saveState.connect(onSaveState);
         widget.context.pathChanged.connect(onPathChanged);
@@ -855,17 +851,15 @@ class PluginPlayground {
         }
       }
 
+      this._notifyLoadCurrentAsExtensionCommandChanged();
+
       app.shell.currentChanged?.connect(() => {
         tokenSidebar.update();
-        if (app.commands.hasCommand(CommandIDs.loadCurrentAsExtension)) {
-          app.commands.notifyCommandChanged(CommandIDs.loadCurrentAsExtension);
-        }
+        this._notifyLoadCurrentAsExtensionCommandChanged();
       });
       editorTracker.currentChanged.connect(() => {
         tokenSidebar.update();
-        if (app.commands.hasCommand(CommandIDs.loadCurrentAsExtension)) {
-          app.commands.notifyCommandChanged(CommandIDs.loadCurrentAsExtension);
-        }
+        this._notifyLoadCurrentAsExtensionCommandChanged();
       });
       app.commands.commandChanged.connect((_, args) => {
         if (args.type === 'added' || args.type === 'removed') {
@@ -916,6 +910,12 @@ class PluginPlayground {
 
   private _isGlobalLoadOnSaveEnabled(): boolean {
     return this.settings.get(LOAD_ON_SAVE_SETTING).composite === true;
+  }
+
+  private _notifyLoadCurrentAsExtensionCommandChanged(): void {
+    if (this.app.commands.hasCommand(CommandIDs.loadCurrentAsExtension)) {
+      this.app.commands.notifyCommandChanged(CommandIDs.loadCurrentAsExtension);
+    }
   }
 
   private _isSupportedPluginSourceFile(path: string): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -413,6 +413,8 @@ class PluginPlayground {
       }
     });
 
+    app.commands.notifyCommandChanged(CommandIDs.loadCurrentAsExtension);
+
     app.commands.addCommand(CommandIDs.exportAsExtension, {
       label: 'Export Plugin Folder As Extension',
       caption:


### PR DESCRIPTION
Fixes #204 

Ensures the Run toolbar button reliably appears after `F5` by triggering a command state refresh right after command registration.
