### PR TITLE
Fix schema-backed dynamic settings to save only user values

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1759,7 +1759,7 @@ class PluginPlayground {
         this.settingRegistry.plugins[plugin.id] = {
           id: plugin.id,
           schema: JSON.parse(schema),
-          raw: schema,
+          raw: '{}',
           data: {
             composite: {},
             user: {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1991,7 +1991,7 @@ class PluginPlayground {
         // - transforms are not applied
         // - any refresh from the server might overwrite the data
         // - it is not a good long term solution in general
-        this.settingRegistry.plugins[plugin.id] = {
+        const dynamicSettingPlugin: ISettingRegistry.IPlugin = {
           id: plugin.id,
           schema: JSON.parse(schema),
           raw: '{}',
@@ -2001,6 +2001,16 @@ class PluginPlayground {
           },
           version: '0.0.0'
         };
+        const validationErrors =
+          this.settingRegistry.validator.validateData(dynamicSettingPlugin);
+        if (validationErrors) {
+          throw new Error(
+            `Could not validate settings for "${plugin.id}". ${validationErrors
+              .map(error => `{${error.keyword}} ${error.message ?? ''}`)
+              .join(' ')}`
+          );
+        }
+        this.settingRegistry.plugins[plugin.id] = dynamicSettingPlugin;
         (
           this.settingRegistry.pluginChanged as Signal<ISettingRegistry, string>
         ).emit(plugin.id);


### PR DESCRIPTION
Fixes #205 

This changes the dynamic setting registry initialization to use an empty user settings payload ({}) instead of the full schema `JSON`. With this change, `settings.set(...)` persists only the actual user setting keys rather than writing back the entire schema.

Test on:- [plugin](https://jupyterlab-plugin-playground.readthedocs.io/en/latest/lite/lab/#plugin=1.g.H4sIAAAAAAAAA-1abXMbtxH-K1tOJiQz5Mlu2n44lUldxU7VkV9GVpoPlseG7pYkbBC4AqBkxtF_7yyAuwOOR8q2pHTS6X0iccDeYnefxYMFPg4uURuu5CB_OBm857Ic5IO5EiXqwWSglbLP2AoH-UBbMV0x_b5UV3IwGcy5QDPIPw4qVrxnC8zeGZIx-HguAc4Hkq3wfJDDeTLufDDxr8M3fY8H2cPsQfPq3braWNSCXdBbJ46aTbHEFfuBaz_G_z0f0Ovrc3k9mISmg0qsF1x21AlCM8EuMoPWcrmY8qJWoPvtrW5TwS5Q-M6nZyfwtDsfy63APe9LNIXmlW3m_NJLNzBXGmhIbSIw66pS2gKX8E-vzgm7yNovbarwIXXxDgvbvKi0qlBbjiaxm1QWL5R6X6t0akX0PpV4oZRAVmsd3qYzI3WfBZHNNOEIhTDJsK0J_7xECSjZhcByAkyIdsYFjab51roauOJCwNogaL5Y2qlVU4FzCxY_WCi5xoIEO2UulF0ClpysCUyWoFGWqLlcZB2F5mwtLClj9Rr9i-s4fHRxwGWJHzJrBvmAr5wXnJ2CH55oJe1jWU562l64qDuX1zDXagXDv7VhfMCqSvCCkcrDw3N5LmvZcBzC4BQX3Fi9gb7hIRB16EMiWgFHarVisnzBBFqLveNZVa0tFyYdWDvxTLPiPerekbU_0pGPS26V3jeOcgO6XunIOl7-xfEK90qoY-PS9YylkO2DCo8_WJSURmrzOcfseNfvmkKVuOJadzT1MkjNVru26wFplfQ_UquKabtCaXsHGMsset8XShoLL05--vH42ZvjH2AGwzhD5j59UV_f8-z5jz-ePH5z9Pzp00fPtrtbtVgInNaemmor_HcOvoHprR_45sBJgqOXL6EQzBgHMWM3AgEFugkTCj3osGxBTckieYKoO1LKG-f07OTN0cmjly_JLu-qaWya1oTU68kxGXFH1ykFrDfbfC19bkFp1hpf0kzNaJzDpeKljz4-h1GpijVNPlugfezt8PfNcTlKnDN1djLD8Rg02rWWhzTc6-RNOINGUKGRWQyyRkP3fjh2I9zvjJdd59fyo06UII-UtOSXGbz1We7gG6hT97afepIv2ZfGZV99bAx8Ddm7aloD-PnaVmvbLiJNSs5BW3FYN5M2Uyb4gtopkR9GafcGvcgl4OHfVaj1pdfqNAxulqNb6fXW_Wn8skRWZqyqUJZHSy7KkTM0Oeb6HmCmSnzqUoazDNZJDNbGLW9JoiG7lRvJVrwAnwbuCWXaivi7M5B4FWsyGqfQWbH3eGpFk4JHYdnPIRCMsfeQB0VHfKbmI--NMAq-j9Jx5peVR9ZqfrG2aKj7R_Jz7rAxhOsx5PDqNYm4Jyf9A0WFOodiicV7ygbMB2vF7BI4ZciU0LmX95gKG7tzc2pFDYInXOCIVMrBWKJD48b8ifWpS4ayND9zuxwNM21F1qTQMfz6a3-PcnhP1n3KuAS_CMKXPfcBAa9Q3s_6_kprw3cwC8tDmbfLu2MkERfOYUixUXN8gnBicRcsfpGt83EnVWdDJ5OtrXppmbaezk68R_-95hpNDq88grr0MtDhvfQJtqghtb5275SbAxPtB1L6mcoPw-vGXvLXymaF5ZfMYg4B_qyqtuwdZJl0WvmuiWI6T5PfNHWZzjzfskXoV_n55lv8-1eQayGSz7eyUuKcdF31GSffxZj9UJfiYPZdvdxRpCqBmVCL0TDehUbrSG3lMlAL6PAcl8ipWaBtrHFqBcxgzoTB5v2tAdYs6gT6hxl4T6CO18BWbwLKDkAExNeiAOBsSVmYNl1oXCq2ym04Y8nOFQauaFdql1iHVFcUN6DkBC7WFq4QmDAKJGIJFeopfR2EWvDCqbdPqzswVZB1AD_jUAiwFAqkvl2iBmTFMswJzFKtRQkX6KZOmWTFJFsgcNvIsEut1oulm3ljVhuii0tjkZWgaGVbCHXBBBw9bZ0xacQYRVZZskuEOZc4XWjGJZYUiVYrkd1PsPwxg0dVJTZwABpX6tJPVMk9AdJdHu5WqWYBppjbPGtRs0184n1ET8LJ5ko_ZsVyVLe_YBJFhPEa5y04iY7FnbPC0__DdkD9Prvi5QKtab7iIjgV7rc39CJbqRJFRtUhmM1mMIxYQTLAhUJN5CmiGjKv3DYh7Uvig1m25IBzWCZViZnbbZ5wYzNWlqNmHzI-TIdcAwqDnybIR8seWXtntZU90t7eKwGDM29CYLSUb8aBtR72WML3__rrMDL07LOMk1-saCXI4wLFLB16uDXQDclKbipmi-VoSzIAzudYWJN3qbjGQsk5X6w1jrZHNQy97xV8Nm3vl1Jz-fTZ6ny915fRn6hj8_M6zq60IDC3w2kQRotAhdLVLV3iKdZa004oLBq93CGA7VFZYkmYlFjY0ejNJEXrOIEffZ9x24Rcm5oV5fP5WogNaGTlpps_PPQ1XiITWGZ2iXI0Gt82cRwchExrFeAHbtwK6XLqb5hcaEjERO4kaWwB_VhSLR2KaJvLpVUuDtxEAmH4P-YjV_zucJ9ENoUJBmYZvGyAEVwp3GP49QS7C9_vM78jK5ZMLmKUd4HnvveTQWDEzrSFEgVzqCKaTZ9ykeMRFJbPeLRBe8ZXqNa9sj8Xg_BlOIRPwiJ8CR5hz0K-S-BNi_lWMARRnw1Z-GzYwm2gSw-dBPVK_SRk--dL8e2fG1Hun7vBun_6Ee-fHQO30B-aoSDb7DLhwUFSRpXKwgbdeauljWPwC_CFVBp75X9CpHUaOppeT-DhgwdxWy8vGd_TdvvbeLv9tLPN7qtHcVlDBu5lB9Ut1FC6aMvHtWGeuwPvbK4Rf8E48umyQd45GKM_Tfl_OGk7h4PgqG7mnzkrrKJikkuxsbd21IzCkc2RknT6THWxbZVjAV8CknGkoL_fkKdhTZk7h2HYX8bzBHBH96HimB6ab9WnTToyrlimUxk-dpx__7k8l_FuaUdQZcMo-tvY97-iyD-AJySEiuiBhOWBhrv6Rm1JX8phsudTLYH3IttsHrh6lMOT9p0c3rf382t3DDALXTyp_mAzao3gTir0l-vH4y3m4Dl4yfVMW0GFjhu3o14TZyVfvOulDd21MFZZ2v91Invbletzuehhx6tnegN8tcKSM4tiM3GlOldhZHNKzClXJBAJZhG45JYzwX9x90limbW7R6keEXmse0zg287qs2dPfKcrz5-yPUe-4bR31JMsxl69u195KI57i-9RFPe-v01uCEhrEBaSxPcuS9CR23D4RbkiAHgH9W6Pzf8rrv_zPtJxc-m2r8bP3a7d-B1Ud-uOl6g3TVHcVaoLJntERYkCuHUo01kX7f3P74IJJXeD-ohQdA4FtyBCx6vV2hI52EWDtu4FuCOlL-E7r1rCA0NSf_h6J_PZF14jfzRSwsWmLuaNP5kJuRBswzgORvrudkB69pK5SoCrk0deag6grKqPT4DbT-VIdwrUv2RwolhZa2TCrcoA3XDTpPDnnr8JJl5oteIGMybE6BWrqkyjsUpTPbZzEpwJxcpRc_o-ft0EVyiJvmqGmNfdFN0c45CQ-n7uyGyfLmd1g9k6z4F07wwzMHRFbDTsuYY7pMS_qpThFmkpCCGdLN7xme7b-Ew3b2Oammfw1cfou9dvUw6wdTAVF3HSxaD9k5qhnnHUu27bKoDFI7fqbs0iQBBIo6ntR14OjS4FhmP2UXobcpIa3l3SzmF45oXecF05xXnB6vsZYXS6wUm3TzfcXk4lc-MlliGhxvGRdMQPWKzpUgEzG1n0U3Z2RecDjeHNrtCawB92uPiGquijsvQpyMM7XHRIyUho7JCP0EreOra46lL1IDHvXGiddHoxiwu3-Azr6QwT3XdQlwbmrvIz0siMkj0UjLCEtGnqomnOuPCVXxHnvuz8XH710YuLQRX0oKvjzoL4ofJc3S2p4brQ4bkcXF__B7-vpAphMQAA)




