### PR TITLE
Fix wheel schema packaging

### DIFF
--- a/src/wheel.ts
+++ b/src/wheel.ts
@@ -982,6 +982,20 @@ export async function createPythonWheelArchive(
     resolvedLabextension.entries,
     resolvedLabextension.fallbackRootName || rootName
   );
+  const rootJupyterlabConfig = getJupyterlabConfig(rootPackageJson) ?? {};
+  const schemaDirValue = rootJupyterlabConfig.schemaDir;
+  const schemaSourcePath =
+    typeof schemaDirValue === 'string' && schemaDirValue.trim().length > 0
+      ? ContentUtils.normalizeContentsPath(
+          schemaDirValue.trim().replace(/\\/g, '/')
+        ).replace(/\/+$/g, '')
+      : '';
+  const hasSchemaSourcePath =
+    schemaSourcePath.length > 0 &&
+    ContentUtils.isSafeRelativePath(schemaSourcePath);
+  const schemaTargetPath = `schemas/${metadata.labextensionName}`;
+  const schemaSourcePrefix = hasSchemaSourcePath ? `${schemaSourcePath}/` : '';
+  const schemaTargetPrefix = `${schemaTargetPath}/`;
 
   const distribution =
     metadata.pythonPackageName.replace(/[^A-Za-z0-9.]+/g, '_') ||
@@ -991,13 +1005,44 @@ export async function createPythonWheelArchive(
     'plugin_playground_export';
   const distInfoPath = `${distribution}-${version}.dist-info`;
   const labextensionPath = `${distribution}-${version}.data/data/share/jupyter/labextensions/${metadata.labextensionName}`;
-
+  let copiedSchemaEntries = false;
   const wheelEntries: IArchiveEntry[] = resolvedLabextension.entries.map(
-    entry => ({
-      path: `${labextensionPath}/${entry.path}`,
-      data: entry.data
-    })
+    entry => {
+      let relativePath = entry.path;
+      if (
+        hasSchemaSourcePath &&
+        (relativePath === schemaSourcePath ||
+          relativePath.startsWith(schemaSourcePrefix))
+      ) {
+        const schemaRelativePath = relativePath
+          .slice(schemaSourcePath.length)
+          .replace(/^\/+/g, '');
+        relativePath = schemaRelativePath
+          ? `${schemaTargetPrefix}${schemaRelativePath}`
+          : schemaTargetPath;
+        copiedSchemaEntries = true;
+      }
+      return {
+        path: `${labextensionPath}/${relativePath}`,
+        data: entry.data
+      };
+    }
   );
+  if (
+    copiedSchemaEntries &&
+    !wheelEntries.some(
+      entry =>
+        entry.path ===
+        `${labextensionPath}/${schemaTargetPath}/package.json.orig`
+    )
+  ) {
+    wheelEntries.push(
+      textArchiveEntry(
+        `${labextensionPath}/${schemaTargetPath}/package.json.orig`,
+        `${JSON.stringify(rootPackageJson, null, 2)}\n`
+      )
+    );
+  }
 
   const hasInstallJson = resolvedLabextension.entries.some(
     entry => entry.path === 'install.json'

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -1697,6 +1697,7 @@ test('wheel export includes license files and sanitized METADATA fields', async 
   const packageJsonPath = `${projectRoot}/package.json`;
   const licensePath = `${projectRoot}/LICENSE`;
   const noticePath = `${projectRoot}/NOTICE`;
+  const schemaPath = `${projectRoot}/schema/plugin.json`;
 
   await page.contents.uploadContent(
     JSON.stringify(
@@ -1709,7 +1710,7 @@ test('wheel export includes license files and sanitized METADATA fields', async 
         author: {
           email: 'owner@example.test\nINJECTED-AUTHOR-EMAIL-LINE'
         },
-        jupyterlab: { extension: true }
+        jupyterlab: { extension: true, schemaDir: 'schema' }
       },
       null,
       2
@@ -1725,6 +1726,19 @@ test('wheel export includes license files and sanitized METADATA fields', async 
   );
   await page.contents.uploadContent('License text\n', 'text', licensePath);
   await page.contents.uploadContent('Notice text\n', 'text', noticePath);
+  await page.contents.uploadContent(
+    JSON.stringify(
+      {
+        title: 'Wheel Export Schema Test',
+        type: 'object',
+        properties: {}
+      },
+      null,
+      2
+    ),
+    'text',
+    schemaPath
+  );
   await page.goto();
 
   await page.filebrowser.open(sourcePath);
@@ -1858,6 +1872,14 @@ test('wheel export includes license files and sanitized METADATA fields', async 
     inspection.entryPaths.some(path =>
       path.endsWith('/licenses/src/license.ts')
     )
+  ).toBe(false);
+  expect(
+    inspection.entryPaths.some(path =>
+      /\/schemas\/.+\/plugin\.json$/.test(path)
+    )
+  ).toBe(true);
+  expect(
+    inspection.entryPaths.some(path => path.endsWith('/schema/plugin.json'))
   ).toBe(false);
   expect(
     inspection.entryPaths.some(path => /(^|\/)\.\.(\/|$)/.test(path))


### PR DESCRIPTION
closes #206 

Place `schemaDir` files under `schemas/<extension-name>/` (and add `package.json.orig`) in exported wheels so settings/menu schemas load after install.





