### PR TITLE
Bump jupyterlab-js-logs to 1.2.0

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -21,10 +21,9 @@ dependencies:
   # additional packages for demos
   # - ipywidgets
   - jupyterlab-lsp
-  - jupyterlab-js-logs>=1.1,<2
+  - jupyterlab-js-logs>=1.2,<2
   - jupyterlab-tour>=4,<5
   # use the same AI package in Binder and JupyterLite deployments
   - jupyterlite-ai>=0.15,<1
   - pip:
       - jupyterlab-open-url-parameter>=0.3,<1
-

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - myst-parser
   - ipywidgets>=8.0,<9
   - jupyterlab>=4.0.0,<5
-  - jupyterlab-js-logs>=1.1,<2
+  - jupyterlab-js-logs>=1.2,<2
   - jupyterlab-tour>=4,<5
   - jupyterlab-language-pack-fr-FR
   - jupyterlab-language-pack-zh-CN

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "@jupyterlab/filebrowser": "^4.5.5",
         "@jupyterlab/fileeditor": "^4.5.5",
         "@jupyterlab/settingregistry": "^4.5.5",
-        "jupyterlab-js-logs": "^1.1.0",
+        "jupyterlab-js-logs": "^1.2.0",
         "raw-loader": "^4.0.2",
         "requirejs": "^2.3.6",
         "typescript": "~5.5.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1868,7 +1868,7 @@ __metadata:
     "@typescript-eslint/parser": ^8.56.1
     eslint: ^9.39.3
     eslint-config-prettier: ^10.1.8
-    jupyterlab-js-logs: ^1.1.0
+    jupyterlab-js-logs: ^1.2.0
     npm-run-all: ^4.1.5
     prettier: ^2.8.0
     raw-loader: ^4.0.2
@@ -2012,7 +2012,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/settingregistry@npm:^4.5.5, @jupyterlab/settingregistry@npm:^4.5.6":
+"@jupyterlab/settingregistry@npm:^4.2.5, @jupyterlab/settingregistry@npm:^4.5.5, @jupyterlab/settingregistry@npm:^4.5.6":
   version: 4.5.6
   resolution: "@jupyterlab/settingregistry@npm:4.5.6"
   dependencies:
@@ -6775,9 +6775,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jupyterlab-js-logs@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "jupyterlab-js-logs@npm:1.1.0"
+"jupyterlab-js-logs@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "jupyterlab-js-logs@npm:1.2.0"
   dependencies:
     "@jupyterlab/application": ^4.2.5
     "@jupyterlab/apputils": ^4.3.5
@@ -6786,10 +6786,11 @@ __metadata:
     "@jupyterlab/mainmenu": ^4.2.5
     "@jupyterlab/nbformat": ^4.2.5
     "@jupyterlab/rendermime": ^4.2.5
+    "@jupyterlab/settingregistry": ^4.2.5
     "@jupyterlab/ui-components": ^4.2.5
     "@lumino/coreutils": ^2.2.0
     "@lumino/widgets": ^2.5.0
-  checksum: 589a8ea6d9e8d770a200a1c769e5d48adef691782ecb2ffc7b8a7b44ab18a7ffd42f49289948d83ff8171a7e71eb2d11d434082f552c8b5cd873638c2003eaae
+  checksum: f72d15d525b28f27fb43391d65134dc48163012553926971314b0131a00cbd89c871583331bf299253906e1e5f85b0e7bec032d5d087248d77e5dde78d703afc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #186 

Updates `jupyterlab-js-logs` from `^1.1.0` to `^1.2.0`, so JS logs default to log instead of debug.