### PR TITLE
Fix launcher SVG import

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -406,6 +406,7 @@ export class ImportResolver {
       const normalizedResolvedPath = resolvedPath.toLowerCase();
       if (normalizedResolvedPath.endsWith('.svg')) {
         return {
+          __esModule: true as unknown as IModuleMember,
           default: content as unknown as IModuleMember
         };
       }


### PR DESCRIPTION
Fixes #216 

Set `__esModule` on local SVG resolver output so `LabIcon.svgstr` gets a string, fixing the broken launcher icon (`[object Object]`).