### PR TITLE
Update minimum required version of `jupyterlab-open-url-parameter`

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -26,4 +26,4 @@ dependencies:
   # use the same AI package in Binder and JupyterLite deployments
   - jupyterlite-ai>=0.15,<1
   - pip:
-      - jupyterlab-open-url-parameter>=0.3,<1
+      - jupyterlab-open-url-parameter>=0.4,<1

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -21,4 +21,4 @@ dependencies:
   - nodejs=18
   - pip:
       - build
-      - jupyterlab-open-url-parameter>=0.3,<1
+      - jupyterlab-open-url-parameter>=0.4,<1


### PR DESCRIPTION
Ensures we pull [`v0.4.0`](https://github.com/jupyterlab-contrib/jupyterlab-open-url-parameter/releases/tag/v0.4.0) of `jupyterlab-open-url-parameter` which includes https://github.com/jupyterlab-contrib/jupyterlab-open-url-parameter/pull/29