### PR TITLE
Fix dynamic settings reload consistency

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2035,7 +2035,9 @@ class PluginPlayground {
         // - any refresh from the server might overwrite the data
         // - it is not a good long term solution in general
         const parsedSchema = JSON.parse(schema) as ISettingRegistry.ISchema;
-        const dynamicSettingRaw = await this._resolveDynamicSettingRaw(plugin.id);
+        const dynamicSettingRaw = await this._resolveDynamicSettingRaw(
+          plugin.id
+        );
         let dynamicSettingPlugin: ISettingRegistry.IPlugin;
         try {
           dynamicSettingPlugin = this._createDynamicSettingPlugin(

--- a/src/index.ts
+++ b/src/index.ts
@@ -2034,11 +2034,28 @@ class PluginPlayground {
         // - transforms are not applied
         // - any refresh from the server might overwrite the data
         // - it is not a good long term solution in general
-        const dynamicSettingPlugin = this._createDynamicSettingPlugin(
-          plugin.id,
-          JSON.parse(schema) as ISettingRegistry.ISchema,
-          await this._resolveDynamicSettingRaw(plugin.id)
-        );
+        const parsedSchema = JSON.parse(schema) as ISettingRegistry.ISchema;
+        const dynamicSettingRaw = await this._resolveDynamicSettingRaw(plugin.id);
+        let dynamicSettingPlugin: ISettingRegistry.IPlugin;
+        try {
+          dynamicSettingPlugin = this._createDynamicSettingPlugin(
+            plugin.id,
+            parsedSchema,
+            dynamicSettingRaw
+          );
+        } catch (error) {
+          if (dynamicSettingRaw === '{}') {
+            throw error;
+          }
+          this._removeDynamicSettingStorageValue(
+            `${DYNAMIC_SETTINGS_STORAGE_KEY_PREFIX}${plugin.id}`
+          );
+          dynamicSettingPlugin = this._createDynamicSettingPlugin(
+            plugin.id,
+            parsedSchema,
+            '{}'
+          );
+        }
         this._dynamicSettingPlugins.set(plugin.id, dynamicSettingPlugin.schema);
         this.settingRegistry.plugins[plugin.id] = dynamicSettingPlugin;
         changedDynamicSettingPluginIds.add(plugin.id);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1977,6 +1977,19 @@ class PluginPlayground {
       string,
       ISettingRegistry.IPlugin | undefined
     >();
+    const removedDynamicSettingStorageValues = new Map<
+      string,
+      { local: string | null; session: string | null }
+    >();
+    const removeDynamicSettingStorageValue = (storageKey: string): void => {
+      if (removedDynamicSettingStorageValues.has(storageKey)) {
+        return;
+      }
+      removedDynamicSettingStorageValues.set(
+        storageKey,
+        this._removeDynamicSettingStorageValue(storageKey)
+      );
+    };
     for (const plugin of plugins) {
       previousDynamicSettingSchemas.set(
         plugin.id,
@@ -2018,7 +2031,7 @@ class PluginPlayground {
           if (hadDynamicSettings || hadSettingsEntry) {
             changedDynamicSettingPluginIds.add(plugin.id);
             delete this.settingRegistry.plugins[plugin.id];
-            this._removeDynamicSettingStorageValue(
+            removeDynamicSettingStorageValue(
               `${DYNAMIC_SETTINGS_STORAGE_KEY_PREFIX}${plugin.id}`
             );
             (
@@ -2049,7 +2062,7 @@ class PluginPlayground {
           if (dynamicSettingRaw === '{}') {
             throw error;
           }
-          this._removeDynamicSettingStorageValue(
+          removeDynamicSettingStorageValue(
             `${DYNAMIC_SETTINGS_STORAGE_KEY_PREFIX}${plugin.id}`
           );
           dynamicSettingPlugin = this._createDynamicSettingPlugin(
@@ -2103,6 +2116,12 @@ class PluginPlayground {
         (
           this.settingRegistry.pluginChanged as Signal<ISettingRegistry, string>
         ).emit(pluginId);
+      }
+      for (const [
+        storageKey,
+        removedValue
+      ] of removedDynamicSettingStorageValues) {
+        this._restoreDynamicSettingStorageValue(storageKey, removedValue);
       }
       const message = error instanceof Error ? error.message : String(error);
       showErrorMessage('Plugin loading failed', message);
@@ -2522,21 +2541,55 @@ class PluginPlayground {
     return false;
   }
 
-  private _removeDynamicSettingStorageValue(storageKey: string): void {
+  private _removeDynamicSettingStorageValue(storageKey: string): {
+    local: string | null;
+    session: string | null;
+  } {
+    let local: string | null = null;
+    let session: string | null = null;
     if (typeof window === 'undefined') {
-      return;
+      return { local, session };
     }
 
     try {
+      local = window.localStorage.getItem(storageKey);
       window.localStorage.removeItem(storageKey);
     } catch {
       // Keep trying the fallback storage.
     }
 
     try {
+      session = window.sessionStorage.getItem(storageKey);
       window.sessionStorage.removeItem(storageKey);
     } catch {
       // Browser storage unavailable.
+    }
+
+    return { local, session };
+  }
+
+  private _restoreDynamicSettingStorageValue(
+    storageKey: string,
+    removedValue: { local: string | null; session: string | null }
+  ): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if (removedValue.local !== null) {
+      try {
+        window.localStorage.setItem(storageKey, removedValue.local);
+      } catch {
+        // Keep trying the fallback storage.
+      }
+    }
+
+    if (removedValue.session !== null) {
+      try {
+        window.sessionStorage.setItem(storageKey, removedValue.session);
+      } catch {
+        // Browser storage unavailable.
+      }
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,8 +142,6 @@ namespace CommandIDs {
   export const listCommands = 'plugin-playground:list-commands';
   export const listExtensionExamples =
     'plugin-playground:list-extension-examples';
-  export const dynamicSettingsState =
-    '__internal:plugin-playground-dynamic-settings-state';
 }
 
 type PluginLoadStatus =
@@ -404,6 +402,7 @@ class PluginPlayground {
       onShowSharedFileToolbarCue: this._showSharedFileToolbarCue.bind(this)
     });
     this._installDynamicSettingsConnectorShim();
+    this._restoreDynamicSettingPluginsFromStorage();
 
     loadKnownModule('@jupyter-widgets/base').then((module: any) => {
       // Define the widgets base module for RequireJS (left for compatibility only)
@@ -819,30 +818,6 @@ class PluginPlayground {
           total: examples.length,
           count: items.length,
           items: [...items]
-        };
-      }
-    });
-    app.commands.addCommand(CommandIDs.dynamicSettingsState, {
-      label: 'Inspect dynamic settings state',
-      caption: 'Internal command for dynamic settings state checks',
-      describedBy: {
-        args: {
-          type: 'object',
-          additionalProperties: false,
-          properties: {
-            pluginId: {
-              type: 'string'
-            }
-          }
-        }
-      },
-      execute: args => {
-        const pluginId =
-          typeof args.pluginId === 'string' ? args.pluginId.trim() : '';
-        return {
-          hasDynamicSchema: this._dynamicSettingPlugins.has(pluginId),
-          hasRegistryPlugin:
-            this.settingRegistry.plugins[pluginId] !== undefined
         };
       }
     });
@@ -2043,6 +2018,9 @@ class PluginPlayground {
           if (hadDynamicSettings || hadSettingsEntry) {
             changedDynamicSettingPluginIds.add(plugin.id);
             delete this.settingRegistry.plugins[plugin.id];
+            this._removeDynamicSettingStorageValue(
+              `${DYNAMIC_SETTINGS_STORAGE_KEY_PREFIX}${plugin.id}`
+            );
             (
               this.settingRegistry.pluginChanged as Signal<
                 ISettingRegistry,
@@ -2056,25 +2034,11 @@ class PluginPlayground {
         // - transforms are not applied
         // - any refresh from the server might overwrite the data
         // - it is not a good long term solution in general
-        const dynamicSettingPlugin: ISettingRegistry.IPlugin = {
-          id: plugin.id,
-          schema: JSON.parse(schema),
-          raw: await this._resolveDynamicSettingRaw(plugin.id),
-          data: {
-            composite: {},
-            user: {}
-          },
-          version: '0.0.0'
-        };
-        const validationErrors =
-          this.settingRegistry.validator.validateData(dynamicSettingPlugin);
-        if (validationErrors) {
-          throw new Error(
-            `Could not validate settings for "${plugin.id}". ${validationErrors
-              .map(error => `{${error.keyword}} ${error.message ?? ''}`)
-              .join(' ')}`
-          );
-        }
+        const dynamicSettingPlugin = this._createDynamicSettingPlugin(
+          plugin.id,
+          JSON.parse(schema) as ISettingRegistry.ISchema,
+          await this._resolveDynamicSettingRaw(plugin.id)
+        );
         this._dynamicSettingPlugins.set(plugin.id, dynamicSettingPlugin.schema);
         this.settingRegistry.plugins[plugin.id] = dynamicSettingPlugin;
         changedDynamicSettingPluginIds.add(plugin.id);
@@ -2137,6 +2101,7 @@ class PluginPlayground {
     for (const plugin of plugins) {
       this._syncPluginLocalStyles(plugin.id, loadedLocalStylePaths);
     }
+    this._syncDynamicSettingStorage();
 
     for (const plugin of plugins) {
       if (!plugin.autoStart) {
@@ -2196,6 +2161,9 @@ class PluginPlayground {
   private _installDynamicSettingsConnectorShim(): void {
     const connector = this.settingRegistry.connector as {
       fetch(id: string): Promise<ISettingRegistry.IPlugin>;
+      list?(
+        query?: 'ids'
+      ): Promise<{ ids: string[]; values: ISettingRegistry.IPlugin[] }>;
       save(id: string, raw: string): Promise<void>;
       __pluginPlaygroundDynamicSettingsPatched__?: boolean;
     };
@@ -2205,7 +2173,51 @@ class PluginPlayground {
     connector.__pluginPlaygroundDynamicSettingsPatched__ = true;
 
     const originalFetch = connector.fetch.bind(connector);
+    const originalList = connector.list?.bind(connector);
     const originalSave = connector.save.bind(connector);
+
+    if (originalList) {
+      connector.list = async (
+        query?: 'ids'
+      ): Promise<{ ids: string[]; values: ISettingRegistry.IPlugin[] }> => {
+        const listed = await originalList(query);
+
+        const ids = new Set(listed.ids ?? []);
+        if (query === 'ids') {
+          for (const pluginId of this._dynamicSettingPlugins.keys()) {
+            ids.add(pluginId);
+          }
+          return {
+            ids: [...ids],
+            values: []
+          };
+        }
+
+        const valuesById = new Map<string, ISettingRegistry.IPlugin>();
+        for (const plugin of listed.values ?? []) {
+          valuesById.set(plugin.id, plugin);
+        }
+
+        for (const [pluginId, schema] of this._dynamicSettingPlugins) {
+          ids.add(pluginId);
+          valuesById.set(pluginId, {
+            id: pluginId,
+            schema,
+            raw: this._readDynamicSettingRaw(pluginId),
+            data: {
+              composite: {},
+              user: {}
+            },
+            version: '0.0.0'
+          });
+        }
+
+        return {
+          ids: [...ids],
+          values: [...valuesById.values()]
+        };
+      };
+    }
 
     connector.fetch = async (
       pluginId: string
@@ -2215,29 +2227,16 @@ class PluginPlayground {
         return originalFetch(pluginId);
       }
 
-      const storedRaw = this._readDynamicSettingRawFromStorage(pluginId);
-      if (storedRaw !== null) {
-        return {
-          id: pluginId,
-          schema,
-          raw: storedRaw,
-          data: {
-            composite: {},
-            user: {}
-          },
-          version: '0.0.0'
-        };
-      }
-
       try {
         const fetched = await originalFetch(pluginId);
         this._writeDynamicSettingRaw(pluginId, fetched.raw);
         return fetched;
       } catch {
+        const storedSetting = this._readStoredDynamicSetting(pluginId);
         return {
           id: pluginId,
           schema,
-          raw: this._readDynamicSettingRaw(pluginId),
+          raw: typeof storedSetting?.raw === 'string' ? storedSetting.raw : '{}',
           data: {
             composite: {},
             user: {}
@@ -2253,12 +2252,13 @@ class PluginPlayground {
         return;
       }
 
-      const savedToBrowserStorage = this._writeDynamicSettingRaw(pluginId, raw);
       try {
         await originalSave(pluginId, raw);
+        this._writeDynamicSettingRaw(pluginId, raw);
       } catch (error) {
         const saveErrorMessage =
           error instanceof Error ? error.message : String(error);
+        const savedToBrowserStorage = this._writeDynamicSettingRaw(pluginId, raw);
         console.warn(
           `[plugin-playground] Failed to save dynamic settings for "${pluginId}" to server.`,
           error
@@ -2272,25 +2272,183 @@ class PluginPlayground {
     };
   }
 
-  private _readDynamicSettingRawFromStorage(pluginId: string): string | null {
+  private _restoreDynamicSettingPluginsFromStorage(): void {
+    for (const pluginId of this._readDynamicSettingPluginIdsFromStorage()) {
+      if (this.settingRegistry.plugins[pluginId] !== undefined) {
+        continue;
+      }
+
+      const storedSetting = this._readStoredDynamicSetting(pluginId);
+      if (!storedSetting?.schema) {
+        continue;
+      }
+
+      try {
+        const dynamicSettingPlugin = this._createDynamicSettingPlugin(
+          pluginId,
+          storedSetting.schema,
+          storedSetting.raw ?? '{}'
+        );
+        this._dynamicSettingPlugins.set(pluginId, dynamicSettingPlugin.schema);
+        this.settingRegistry.plugins[pluginId] = dynamicSettingPlugin;
+        (
+          this.settingRegistry.pluginChanged as Signal<ISettingRegistry, string>
+        ).emit(pluginId);
+      } catch (error) {
+        console.warn(
+          `[plugin-playground] Failed to restore dynamic settings schema for "${pluginId}".`,
+          error
+        );
+        this._removeDynamicSettingStorageValue(
+          `${DYNAMIC_SETTINGS_STORAGE_KEY_PREFIX}${pluginId}`
+        );
+      }
+    }
+  }
+
+  private _createDynamicSettingPlugin(
+    pluginId: string,
+    schema: ISettingRegistry.ISchema,
+    raw: string
+  ): ISettingRegistry.IPlugin {
+    const dynamicSettingPlugin: ISettingRegistry.IPlugin = {
+      id: pluginId,
+      schema,
+      raw,
+      data: {
+        composite: {},
+        user: {}
+      },
+      version: '0.0.0'
+    };
+    const validationErrors =
+      this.settingRegistry.validator.validateData(dynamicSettingPlugin);
+    if (validationErrors) {
+      throw new Error(
+        `Could not validate settings for "${pluginId}". ${validationErrors
+          .map(error => `{${error.keyword}} ${error.message ?? ''}`)
+          .join(' ')}`
+      );
+    }
+    return dynamicSettingPlugin;
+  }
+
+  private _syncDynamicSettingStorage(): void {
+    const storedPluginIds = this._readDynamicSettingPluginIdsFromStorage();
+    for (const pluginId of storedPluginIds) {
+      if (!this._dynamicSettingPlugins.has(pluginId)) {
+        this._removeDynamicSettingStorageValue(
+          `${DYNAMIC_SETTINGS_STORAGE_KEY_PREFIX}${pluginId}`
+        );
+      }
+    }
+
+    for (const [pluginId, schema] of this._dynamicSettingPlugins) {
+      this._writeStoredDynamicSetting(
+        pluginId,
+        this._readDynamicSettingRaw(pluginId),
+        schema
+      );
+    }
+  }
+
+  private _readDynamicSettingPluginIdsFromStorage(): Set<string> {
+    const pluginIds = new Set<string>();
+    if (typeof window === 'undefined') {
+      return pluginIds;
+    }
+
+    const collectPluginIds = (storage: Storage): void => {
+      for (let index = 0; index < storage.length; index += 1) {
+        const key = storage.key(index);
+        if (!key || !key.startsWith(DYNAMIC_SETTINGS_STORAGE_KEY_PREFIX)) {
+          continue;
+        }
+        pluginIds.add(key.slice(DYNAMIC_SETTINGS_STORAGE_KEY_PREFIX.length));
+      }
+    };
+
+    try {
+      collectPluginIds(window.localStorage);
+    } catch {
+      // Local storage unavailable.
+    }
+
+    try {
+      collectPluginIds(window.sessionStorage);
+    } catch {
+      // Session storage unavailable.
+    }
+
+    return pluginIds;
+  }
+
+  private _readStoredDynamicSetting(
+    pluginId: string
+  ): { raw?: string; schema?: ISettingRegistry.ISchema } | null {
+    const storageKey = `${DYNAMIC_SETTINGS_STORAGE_KEY_PREFIX}${pluginId}`;
+    const storedValue = this._readDynamicSettingStorageValue(storageKey);
+    if (storedValue === null) {
+      return null;
+    }
+
+    try {
+      const parsed = JSON.parse(storedValue) as {
+        raw?: unknown;
+        schema?: unknown;
+      };
+      if (
+        parsed &&
+        typeof parsed === 'object' &&
+        ('raw' in parsed || 'schema' in parsed)
+      ) {
+        const raw = typeof parsed.raw === 'string' ? parsed.raw : undefined;
+        const schema =
+          parsed.schema && typeof parsed.schema === 'object'
+            ? (parsed.schema as ISettingRegistry.ISchema)
+            : undefined;
+        return { raw, schema };
+      }
+    } catch {
+      // Legacy storage format where raw settings were stored directly as text.
+    }
+
+    return {
+      raw: storedValue
+    };
+  }
+
+  private _writeStoredDynamicSetting(
+    pluginId: string,
+    raw: string,
+    schema?: ISettingRegistry.ISchema
+  ): boolean {
+    const storageKey = `${DYNAMIC_SETTINGS_STORAGE_KEY_PREFIX}${pluginId}`;
+    const persisted = JSON.stringify({
+      raw,
+      schema
+    });
+    return this._writeDynamicSettingStorageValue(storageKey, persisted);
+  }
+
+  private _readDynamicSettingStorageValue(storageKey: string): string | null {
     if (typeof window === 'undefined') {
       return null;
     }
 
-    const storageKey = `${DYNAMIC_SETTINGS_STORAGE_KEY_PREFIX}${pluginId}`;
     try {
-      const storedRaw = window.localStorage.getItem(storageKey);
-      if (storedRaw !== null) {
-        return storedRaw;
+      const storedValue = window.localStorage.getItem(storageKey);
+      if (storedValue !== null) {
+        return storedValue;
       }
     } catch {
       // Continue to sessionStorage fallback.
     }
 
     try {
-      const storedRaw = window.sessionStorage.getItem(storageKey);
-      if (storedRaw !== null) {
-        return storedRaw;
+      const storedValue = window.sessionStorage.getItem(storageKey);
+      if (storedValue !== null) {
+        return storedValue;
       }
     } catch {
       // No browser storage available.
@@ -2299,16 +2457,54 @@ class PluginPlayground {
     return null;
   }
 
+  private _writeDynamicSettingStorageValue(
+    storageKey: string,
+    value: string
+  ): boolean {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+
+    try {
+      window.localStorage.setItem(storageKey, value);
+      return true;
+    } catch {
+      // Fall through to sessionStorage.
+    }
+
+    try {
+      window.sessionStorage.setItem(storageKey, value);
+      return true;
+    } catch {
+      // No browser storage available.
+    }
+    return false;
+  }
+
+  private _removeDynamicSettingStorageValue(storageKey: string): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      window.localStorage.removeItem(storageKey);
+    } catch {
+      // Keep trying the fallback storage.
+    }
+
+    try {
+      window.sessionStorage.removeItem(storageKey);
+    } catch {
+      // Browser storage unavailable.
+    }
+  }
+
   private _readDynamicSettingRaw(pluginId: string): string {
-    return this._readDynamicSettingRawFromStorage(pluginId) ?? '{}';
+    const storedSetting = this._readStoredDynamicSetting(pluginId);
+    return typeof storedSetting?.raw === 'string' ? storedSetting.raw : '{}';
   }
 
   private async _resolveDynamicSettingRaw(pluginId: string): Promise<string> {
-    const storedRaw = this._readDynamicSettingRawFromStorage(pluginId);
-    if (storedRaw !== null) {
-      return storedRaw;
-    }
-
     const connector = this.settingRegistry.connector as {
       fetch(id: string): Promise<ISettingRegistry.IPlugin>;
     };
@@ -2321,29 +2517,18 @@ class PluginPlayground {
     } catch {
       // Keep default fallback when connector has no dynamic entry.
     }
+    const storedSetting = this._readStoredDynamicSetting(pluginId);
+    if (typeof storedSetting?.raw === 'string') {
+      return storedSetting.raw;
+    }
     return '{}';
   }
 
   private _writeDynamicSettingRaw(pluginId: string, raw: string): boolean {
-    if (typeof window === 'undefined') {
-      return false;
-    }
-
-    const storageKey = `${DYNAMIC_SETTINGS_STORAGE_KEY_PREFIX}${pluginId}`;
-    try {
-      window.localStorage.setItem(storageKey, raw);
-      return true;
-    } catch {
-      // Fall through to sessionStorage.
-    }
-
-    try {
-      window.sessionStorage.setItem(storageKey, raw);
-      return true;
-    } catch {
-      // No browser storage available.
-    }
-    return false;
+    const schema =
+      this._dynamicSettingPlugins.get(pluginId) ??
+      this._readStoredDynamicSetting(pluginId)?.schema;
+    return this._writeStoredDynamicSetting(pluginId, raw, schema);
   }
 
   private _refreshExtensionPoints(): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,6 +142,8 @@ namespace CommandIDs {
   export const listCommands = 'plugin-playground:list-commands';
   export const listExtensionExamples =
     'plugin-playground:list-extension-examples';
+  export const dynamicSettingsState =
+    '__internal:plugin-playground-dynamic-settings-state';
 }
 
 type PluginLoadStatus =
@@ -351,6 +353,8 @@ const NOTEBOOK_TREE_OPEN_SIDEBAR_KEY =
   'plugin-playground:open-sidebar-from-tree';
 const NOTEBOOK_TREE_OPEN_AI_CHAT_KEY =
   'plugin-playground:open-ai-chat-from-tree';
+const DYNAMIC_SETTINGS_STORAGE_KEY_PREFIX =
+  'plugin-playground:dynamic-settings:';
 const NOTEBOOK_SHELL_PLUGIN_ID =
   '@jupyter-notebook/application-extension:shell';
 const NOTEBOOK_TREE_WIDGET_PLUGIN_ID =
@@ -399,6 +403,7 @@ class PluginPlayground {
       joinPath: this._joinPath.bind(this),
       onShowSharedFileToolbarCue: this._showSharedFileToolbarCue.bind(this)
     });
+    this._installDynamicSettingsConnectorShim();
 
     loadKnownModule('@jupyter-widgets/base').then((module: any) => {
       // Define the widgets base module for RequireJS (left for compatibility only)
@@ -817,7 +822,30 @@ class PluginPlayground {
         };
       }
     });
-
+    app.commands.addCommand(CommandIDs.dynamicSettingsState, {
+      label: 'Inspect dynamic settings state',
+      caption: 'Internal command for dynamic settings state checks',
+      describedBy: {
+        args: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            pluginId: {
+              type: 'string'
+            }
+          }
+        }
+      },
+      execute: args => {
+        const pluginId =
+          typeof args.pluginId === 'string' ? args.pluginId.trim() : '';
+        return {
+          hasDynamicSchema: this._dynamicSettingPlugins.has(pluginId),
+          hasRegistryPlugin:
+            this.settingRegistry.plugins[pluginId] !== undefined
+        };
+      }
+    });
     app.restored.then(async () => {
       const settings = this.settings;
       this._updateSettings(requirejs, settings);
@@ -1965,6 +1993,25 @@ class PluginPlayground {
     const skippedAutoStartPluginIds: string[] = [];
     const loadedLocalStylePaths = importResolver.loadedLocalStylePaths;
     const newlyRegisteredPluginIds: string[] = [];
+    const changedDynamicSettingPluginIds = new Set<string>();
+    const previousDynamicSettingSchemas = new Map<
+      string,
+      ISettingRegistry.ISchema | undefined
+    >();
+    const previousSettingRegistryPlugins = new Map<
+      string,
+      ISettingRegistry.IPlugin | undefined
+    >();
+    for (const plugin of plugins) {
+      previousDynamicSettingSchemas.set(
+        plugin.id,
+        this._dynamicSettingPlugins.get(plugin.id)
+      );
+      previousSettingRegistryPlugins.set(
+        plugin.id,
+        this.settingRegistry.plugins[plugin.id]
+      );
+    }
 
     try {
       for (const declaredStylePath of result.declaredStylePaths) {
@@ -1988,6 +2035,21 @@ class PluginPlayground {
       for (const plugin of plugins) {
         const schema = result.schemas[plugin.id];
         if (!schema) {
+          const hadDynamicSettings = this._dynamicSettingPlugins.delete(
+            plugin.id
+          );
+          const hadSettingsEntry =
+            this.settingRegistry.plugins[plugin.id] !== undefined;
+          if (hadDynamicSettings || hadSettingsEntry) {
+            changedDynamicSettingPluginIds.add(plugin.id);
+            delete this.settingRegistry.plugins[plugin.id];
+            (
+              this.settingRegistry.pluginChanged as Signal<
+                ISettingRegistry,
+                string
+              >
+            ).emit(plugin.id);
+          }
           continue;
         }
         // TODO: this is mostly fine to get the menus and toolbars, but:
@@ -1997,7 +2059,7 @@ class PluginPlayground {
         const dynamicSettingPlugin: ISettingRegistry.IPlugin = {
           id: plugin.id,
           schema: JSON.parse(schema),
-          raw: '{}',
+          raw: this._readDynamicSettingRaw(plugin.id),
           data: {
             composite: {},
             user: {}
@@ -2013,7 +2075,9 @@ class PluginPlayground {
               .join(' ')}`
           );
         }
+        this._dynamicSettingPlugins.set(plugin.id, dynamicSettingPlugin.schema);
         this.settingRegistry.plugins[plugin.id] = dynamicSettingPlugin;
+        changedDynamicSettingPluginIds.add(plugin.id);
         (
           this.settingRegistry.pluginChanged as Signal<ISettingRegistry, string>
         ).emit(plugin.id);
@@ -2038,6 +2102,24 @@ class PluginPlayground {
             cleanupError
           );
         }
+      }
+      for (const pluginId of changedDynamicSettingPluginIds) {
+        const previousSchema = previousDynamicSettingSchemas.get(pluginId);
+        if (previousSchema === undefined) {
+          this._dynamicSettingPlugins.delete(pluginId);
+        } else {
+          this._dynamicSettingPlugins.set(pluginId, previousSchema);
+        }
+
+        const previousPlugin = previousSettingRegistryPlugins.get(pluginId);
+        if (previousPlugin === undefined) {
+          delete this.settingRegistry.plugins[pluginId];
+        } else {
+          this.settingRegistry.plugins[pluginId] = previousPlugin;
+        }
+        (
+          this.settingRegistry.pluginChanged as Signal<ISettingRegistry, string>
+        ).emit(pluginId);
       }
       const message = error instanceof Error ? error.message : String(error);
       showErrorMessage('Plugin loading failed', message);
@@ -2109,6 +2191,109 @@ class PluginPlayground {
       transpiled: result.transpiled,
       skippedAutoStartPluginIds: skippedAutoStartPluginIdsResult
     };
+  }
+
+  private _installDynamicSettingsConnectorShim(): void {
+    const connector = this.settingRegistry.connector as {
+      fetch(id: string): Promise<ISettingRegistry.IPlugin>;
+      save(id: string, raw: string): Promise<void>;
+      __pluginPlaygroundDynamicSettingsPatched__?: boolean;
+    };
+    if (connector.__pluginPlaygroundDynamicSettingsPatched__) {
+      return;
+    }
+    connector.__pluginPlaygroundDynamicSettingsPatched__ = true;
+
+    const originalFetch = connector.fetch.bind(connector);
+    const originalSave = connector.save.bind(connector);
+
+    connector.fetch = async (
+      pluginId: string
+    ): Promise<ISettingRegistry.IPlugin> => {
+      const schema = this._dynamicSettingPlugins.get(pluginId);
+      if (!schema) {
+        return originalFetch(pluginId);
+      }
+
+      try {
+        const fetched = await originalFetch(pluginId);
+        this._writeDynamicSettingRaw(pluginId, fetched.raw);
+        return fetched;
+      } catch {
+        return {
+          id: pluginId,
+          schema,
+          raw: this._readDynamicSettingRaw(pluginId),
+          data: {
+            composite: {},
+            user: {}
+          },
+          version: '0.0.0'
+        };
+      }
+    };
+
+    connector.save = async (pluginId: string, raw: string): Promise<void> => {
+      if (!this._dynamicSettingPlugins.has(pluginId)) {
+        await originalSave(pluginId, raw);
+        return;
+      }
+
+      // Keep a local copy for dynamic-only plugins when server-side schema is unavailable.
+      this._writeDynamicSettingRaw(pluginId, raw);
+      try {
+        await originalSave(pluginId, raw);
+      } catch {
+        // Swallow server save errors for dynamic-only plugins and keep local fallback.
+      }
+    };
+  }
+
+  private _readDynamicSettingRaw(pluginId: string): string {
+    if (typeof window === 'undefined') {
+      return '{}';
+    }
+
+    const storageKey = `${DYNAMIC_SETTINGS_STORAGE_KEY_PREFIX}${pluginId}`;
+    try {
+      const storedRaw = window.localStorage.getItem(storageKey);
+      if (storedRaw !== null) {
+        return storedRaw;
+      }
+    } catch {
+      // Continue to sessionStorage fallback.
+    }
+
+    try {
+      const storedRaw = window.sessionStorage.getItem(storageKey);
+      if (storedRaw !== null) {
+        return storedRaw;
+      }
+    } catch {
+      // No browser storage available.
+    }
+
+    return '{}';
+  }
+
+  private _writeDynamicSettingRaw(pluginId: string, raw: string): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const storageKey = `${DYNAMIC_SETTINGS_STORAGE_KEY_PREFIX}${pluginId}`;
+    try {
+      window.localStorage.setItem(storageKey, raw);
+      return;
+    } catch {
+      // Fall through to sessionStorage.
+    }
+
+    try {
+      window.sessionStorage.setItem(storageKey, raw);
+    } catch {
+      // No browser storage available.
+    }
   }
 
   private _refreshExtensionPoints(): void {
@@ -2280,25 +2465,84 @@ class PluginPlayground {
   private _ensureDeactivateSupport(
     plugin: IPlugin<JupyterFrontEnd, unknown>
   ): IPlugin<JupyterFrontEnd, unknown> {
-    const trackedCommandDisposables: Array<{ dispose: () => void }> = [];
+    const noopDisposable = {
+      dispose(): void {
+        // no-op
+      }
+    };
+    const trackedCommandDisposables = new Map<
+      string,
+      { dispose: () => void }
+    >();
+    const disposeTrackedCommands = (): void => {
+      for (const [id, disposable] of trackedCommandDisposables) {
+        try {
+          disposable.dispose();
+        } catch (error) {
+          console.warn(`Failed to dispose plugin command "${id}"`, error);
+        }
+      }
+      trackedCommandDisposables.clear();
+    };
+    let activationNonce = 0;
+    let isDeactivated = false;
     const originalActivate = plugin.activate;
     const originalDeactivate = plugin.deactivate;
 
     plugin.activate = async (app: JupyterFrontEnd, ...services: unknown[]) => {
-      const originalAddCommand = app.commands.addCommand.bind(app.commands);
-      app.commands.addCommand = ((id, options) => {
-        const disposable = originalAddCommand(id, options);
-        trackedCommandDisposables.push(disposable);
-        return disposable;
+      activationNonce += 1;
+      const currentActivationNonce = activationNonce;
+      isDeactivated = false;
+
+      const proxyCommands = Object.create(app.commands) as typeof app.commands;
+      const addCommand = app.commands.addCommand.bind(app.commands);
+      proxyCommands.addCommand = ((id, options) => {
+        if (isDeactivated || currentActivationNonce !== activationNonce) {
+          return noopDisposable;
+        }
+
+        if (app.commands.hasCommand(id)) {
+          const existingDisposable = trackedCommandDisposables.get(id);
+          if (existingDisposable) {
+            try {
+              existingDisposable.dispose();
+            } catch (error) {
+              console.warn(`Failed to dispose stale command "${id}"`, error);
+            } finally {
+              trackedCommandDisposables.delete(id);
+            }
+          } else {
+            console.warn(
+              `Skipping duplicate command "${id}" from "${plugin.id}" because it is already registered by another source.`
+            );
+            return noopDisposable;
+          }
+        }
+
+        const disposable = addCommand(id, options);
+        trackedCommandDisposables.set(id, disposable);
+        return {
+          dispose: () => {
+            trackedCommandDisposables.delete(id);
+            disposable.dispose();
+          }
+        };
       }) as typeof app.commands.addCommand;
 
+      const proxyApp = Object.create(app) as JupyterFrontEnd;
+      (
+        proxyApp as JupyterFrontEnd & {
+          commands: typeof app.commands;
+        }
+      ).commands = proxyCommands;
+
       try {
-        return await originalActivate(app, ...services);
+        return await originalActivate(proxyApp, ...services);
       } catch (error) {
-        this._disposeTrackedCommands(trackedCommandDisposables);
+        isDeactivated = true;
+        activationNonce += 1;
+        disposeTrackedCommands();
         throw error;
-      } finally {
-        app.commands.addCommand = originalAddCommand;
       }
     };
 
@@ -2306,32 +2550,18 @@ class PluginPlayground {
       app: JupyterFrontEnd,
       ...services: unknown[]
     ) => {
+      isDeactivated = true;
+      activationNonce += 1;
       try {
         if (originalDeactivate) {
           await originalDeactivate(app, ...services);
         }
       } finally {
-        this._disposeTrackedCommands(trackedCommandDisposables);
+        disposeTrackedCommands();
       }
     };
 
     return plugin;
-  }
-
-  private _disposeTrackedCommands(
-    trackedCommandDisposables: Array<{ dispose: () => void }>
-  ): void {
-    while (trackedCommandDisposables.length > 0) {
-      const disposable = trackedCommandDisposables.pop();
-      if (!disposable) {
-        continue;
-      }
-      try {
-        disposable.dispose();
-      } catch (error) {
-        console.warn('Failed to dispose plugin command registration', error);
-      }
-    }
   }
 
   private async _deactivateAndDeregisterPlugin(
@@ -3340,6 +3570,10 @@ class PluginPlayground {
     MainAreaWidget<IFrame>
   >();
   private readonly _pluginLocalStylePaths = new Map<string, Set<string>>();
+  private readonly _dynamicSettingPlugins = new Map<
+    string,
+    ISettingRegistry.ISchema
+  >();
   private _commandInsertMode: CommandInsertMode = DEFAULT_COMMAND_INSERT_MODE;
   private _playgroundSidebar: SidePanel | null = null;
   private _tokenSidebar: TokenSidebar | null = null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2215,6 +2215,20 @@ class PluginPlayground {
         return originalFetch(pluginId);
       }
 
+      const storedRaw = this._readDynamicSettingRawFromStorage(pluginId);
+      if (storedRaw !== null) {
+        return {
+          id: pluginId,
+          schema,
+          raw: storedRaw,
+          data: {
+            composite: {},
+            user: {}
+          },
+          version: '0.0.0'
+        };
+      }
+
       try {
         const fetched = await originalFetch(pluginId);
         this._writeDynamicSettingRaw(pluginId, fetched.raw);
@@ -2249,9 +2263,9 @@ class PluginPlayground {
     };
   }
 
-  private _readDynamicSettingRaw(pluginId: string): string {
+  private _readDynamicSettingRawFromStorage(pluginId: string): string | null {
     if (typeof window === 'undefined') {
-      return '{}';
+      return null;
     }
 
     const storageKey = `${DYNAMIC_SETTINGS_STORAGE_KEY_PREFIX}${pluginId}`;
@@ -2273,7 +2287,11 @@ class PluginPlayground {
       // No browser storage available.
     }
 
-    return '{}';
+    return null;
+  }
+
+  private _readDynamicSettingRaw(pluginId: string): string {
+    return this._readDynamicSettingRawFromStorage(pluginId) ?? '{}';
   }
 
   private _writeDynamicSettingRaw(pluginId: string, raw: string): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2236,7 +2236,8 @@ class PluginPlayground {
         return {
           id: pluginId,
           schema,
-          raw: typeof storedSetting?.raw === 'string' ? storedSetting.raw : '{}',
+          raw:
+            typeof storedSetting?.raw === 'string' ? storedSetting.raw : '{}',
           data: {
             composite: {},
             user: {}
@@ -2258,7 +2259,10 @@ class PluginPlayground {
       } catch (error) {
         const saveErrorMessage =
           error instanceof Error ? error.message : String(error);
-        const savedToBrowserStorage = this._writeDynamicSettingRaw(pluginId, raw);
+        const savedToBrowserStorage = this._writeDynamicSettingRaw(
+          pluginId,
+          raw
+        );
         console.warn(
           `[plugin-playground] Failed to save dynamic settings for "${pluginId}" to server.`,
           error

--- a/src/index.ts
+++ b/src/index.ts
@@ -2253,12 +2253,21 @@ class PluginPlayground {
         return;
       }
 
-      // Keep a local copy for dynamic-only plugins when server-side schema is unavailable.
-      this._writeDynamicSettingRaw(pluginId, raw);
+      const savedToBrowserStorage = this._writeDynamicSettingRaw(pluginId, raw);
       try {
         await originalSave(pluginId, raw);
-      } catch {
-        // Swallow server save errors for dynamic-only plugins and keep local fallback.
+      } catch (error) {
+        const saveErrorMessage =
+          error instanceof Error ? error.message : String(error);
+        console.warn(
+          `[plugin-playground] Failed to save dynamic settings for "${pluginId}" to server.`,
+          error
+        );
+        if (!savedToBrowserStorage) {
+          throw new Error(
+            `Could not persist settings for "${pluginId}" because browser storage is unavailable and server save failed: ${saveErrorMessage}`
+          );
+        }
       }
     };
   }
@@ -2315,24 +2324,26 @@ class PluginPlayground {
     return '{}';
   }
 
-  private _writeDynamicSettingRaw(pluginId: string, raw: string): void {
+  private _writeDynamicSettingRaw(pluginId: string, raw: string): boolean {
     if (typeof window === 'undefined') {
-      return;
+      return false;
     }
 
     const storageKey = `${DYNAMIC_SETTINGS_STORAGE_KEY_PREFIX}${pluginId}`;
     try {
       window.localStorage.setItem(storageKey, raw);
-      return;
+      return true;
     } catch {
       // Fall through to sessionStorage.
     }
 
     try {
       window.sessionStorage.setItem(storageKey, raw);
+      return true;
     } catch {
       // No browser storage available.
     }
+    return false;
   }
 
   private _refreshExtensionPoints(): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2059,7 +2059,7 @@ class PluginPlayground {
         const dynamicSettingPlugin: ISettingRegistry.IPlugin = {
           id: plugin.id,
           schema: JSON.parse(schema),
-          raw: this._readDynamicSettingRaw(plugin.id),
+          raw: await this._resolveDynamicSettingRaw(plugin.id),
           data: {
             composite: {},
             user: {}
@@ -2292,6 +2292,27 @@ class PluginPlayground {
 
   private _readDynamicSettingRaw(pluginId: string): string {
     return this._readDynamicSettingRawFromStorage(pluginId) ?? '{}';
+  }
+
+  private async _resolveDynamicSettingRaw(pluginId: string): Promise<string> {
+    const storedRaw = this._readDynamicSettingRawFromStorage(pluginId);
+    if (storedRaw !== null) {
+      return storedRaw;
+    }
+
+    const connector = this.settingRegistry.connector as {
+      fetch(id: string): Promise<ISettingRegistry.IPlugin>;
+    };
+    try {
+      const fetched = await connector.fetch(pluginId);
+      if (typeof fetched.raw === 'string') {
+        this._writeDynamicSettingRaw(pluginId, fetched.raw);
+        return fetched.raw;
+      }
+    } catch {
+      // Keep default fallback when connector has no dynamic entry.
+    }
+    return '{}';
   }
 
   private _writeDynamicSettingRaw(pluginId: string, raw: string): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2229,8 +2229,26 @@ class PluginPlayground {
 
       try {
         const fetched = await originalFetch(pluginId);
-        this._writeDynamicSettingRaw(pluginId, fetched.raw);
-        return fetched;
+        const normalizedFetched: ISettingRegistry.IPlugin = {
+          ...fetched,
+          id: pluginId,
+          schema: fetched.schema ?? schema,
+          raw:
+            typeof fetched.raw === 'string'
+              ? fetched.raw
+              : this._readDynamicSettingRaw(pluginId),
+          data: fetched.data ?? {
+            composite: {},
+            user: {}
+          },
+          version: fetched.version ?? '0.0.0'
+        };
+        this._writeStoredDynamicSetting(
+          pluginId,
+          normalizedFetched.raw,
+          normalizedFetched.schema
+        );
+        return normalizedFetched;
       } catch {
         const storedSetting = this._readStoredDynamicSetting(pluginId);
         return {

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -1953,16 +1953,18 @@ test('persists dynamic plugin settings in browser storage', async ({
   }, DYNAMIC_SETTINGS_PERSIST_TEST_PLUGIN_ID);
   expect(storedDynamicSetting).not.toBeNull();
 
-  const parsedStoredDynamicSetting = JSON.parse(storedDynamicSetting ?? '{}') as
+  const parsedStoredDynamicSetting = JSON.parse(
+    storedDynamicSetting ?? '{}'
+  ) as
     | {
         raw?: string;
         schema?: { properties?: { enabled?: { default?: boolean } } };
       }
     | undefined;
   expect(parsedStoredDynamicSetting?.raw).toContain('"enabled": true');
-  expect(
-    parsedStoredDynamicSetting?.schema?.properties?.enabled?.default
-  ).toBe(false);
+  expect(parsedStoredDynamicSetting?.schema?.properties?.enabled?.default).toBe(
+    false
+  );
 });
 
 test('exports active extension folder as a zip archive', async ({

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -286,6 +286,20 @@ const DYNAMIC_SETTINGS_PERSIST_TEST_SCHEMA = JSON.stringify(
   null,
   2
 );
+const DYNAMIC_SETTINGS_PERSIST_TEST_SCHEMA_UPDATED = JSON.stringify(
+  {
+    title: 'Dynamic settings persist test schema updated',
+    type: 'object',
+    properties: {
+      enabled: {
+        type: 'number',
+        default: 0
+      }
+    }
+  },
+  null,
+  2
+);
 
 async function openSidebarPanel(
   page: IJupyterLabPageFixture,
@@ -1904,18 +1918,23 @@ test('persists dynamic plugin settings in browser storage', async ({
   );
   await page.goto();
 
+  const waitForCommand = async (commandId: string) => {
+    await page.waitForFunction((id: string) => {
+      return Boolean((window as any).jupyterapp?.commands?.hasCommand(id));
+    }, commandId);
+  };
+
   const openSourceInEditor = async () => {
-    await page.filebrowser.open(sourcePath);
+    await waitForCommand('docmanager:open');
+    await page.evaluate(async (path: string) => {
+      await window.jupyterapp.commands.execute('docmanager:open', { path });
+    }, sourcePath);
     expect(await page.activity.activateTab('index.ts')).toBe(true);
   };
 
   await openSourceInEditor();
 
-  await page.waitForCondition(() =>
-    page.evaluate((id: string) => {
-      return window.jupyterapp.commands.hasCommand(id);
-    }, LOAD_COMMAND)
-  );
+  await waitForCommand(LOAD_COMMAND);
 
   const firstLoadResult = await page.evaluate((id: string) => {
     return window.jupyterapp.commands.execute(id);
@@ -1926,11 +1945,7 @@ test('persists dynamic plugin settings in browser storage', async ({
     DYNAMIC_SETTINGS_PERSIST_TEST_PLUGIN_ID
   );
 
-  await page.waitForCondition(() =>
-    page.evaluate((id: string) => {
-      return window.jupyterapp.commands.hasCommand(id);
-    }, DYNAMIC_SETTINGS_PERSIST_TEST_SET_COMMAND)
-  );
+  await waitForCommand(DYNAMIC_SETTINGS_PERSIST_TEST_SET_COMMAND);
 
   const setResult = await page.evaluate(
     ({ commandId, enabled }) => {
@@ -1964,6 +1979,109 @@ test('persists dynamic plugin settings in browser storage', async ({
   expect(parsedStoredDynamicSetting?.raw).toContain('"enabled": true');
   expect(parsedStoredDynamicSetting?.schema?.properties?.enabled?.default).toBe(
     false
+  );
+
+  const refreshedPage = await page.context().newPage();
+  try {
+    await refreshedPage.goto(page.url(), { waitUntil: 'domcontentloaded' });
+    const storedDynamicSettingAfterRefresh = await refreshedPage.evaluate(
+      (pluginId: string) => {
+        const key = `plugin-playground:dynamic-settings:${pluginId}`;
+        return (
+          window.localStorage.getItem(key) ??
+          window.sessionStorage.getItem(key)
+        );
+      },
+      DYNAMIC_SETTINGS_PERSIST_TEST_PLUGIN_ID
+    );
+    expect(storedDynamicSettingAfterRefresh).not.toBeNull();
+
+    const parsedStoredDynamicSettingAfterRefresh = JSON.parse(
+      storedDynamicSettingAfterRefresh ?? '{}'
+    ) as
+      | {
+          raw?: string;
+          schema?: { properties?: { enabled?: { default?: boolean } } };
+        }
+      | undefined;
+    expect(parsedStoredDynamicSettingAfterRefresh?.raw).toContain(
+      '"enabled": true'
+    );
+    expect(
+      parsedStoredDynamicSettingAfterRefresh?.schema?.properties?.enabled
+        ?.default
+    ).toBe(false);
+  } finally {
+    await refreshedPage.close();
+  }
+});
+
+test('reloads when dynamic settings schema changes and stored raw becomes incompatible', async ({
+  page,
+  tmpPath
+}) => {
+  const projectRoot = `${tmpPath}/dynamic-settings-schema-change-test`;
+  const sourcePath = `${projectRoot}/index.ts`;
+  const schemaPath = `${projectRoot}/plugin.json`;
+
+  await page.contents.uploadContent(
+    DYNAMIC_SETTINGS_PERSIST_TEST_SOURCE,
+    'text',
+    sourcePath
+  );
+  await page.contents.uploadContent(
+    DYNAMIC_SETTINGS_PERSIST_TEST_SCHEMA,
+    'text',
+    schemaPath
+  );
+  await page.goto();
+
+  const waitForCommand = async (commandId: string) => {
+    await page.waitForFunction((id: string) => {
+      return Boolean((window as any).jupyterapp?.commands?.hasCommand(id));
+    }, commandId);
+  };
+
+  const openSourceInEditor = async () => {
+    await waitForCommand('docmanager:open');
+    await page.evaluate(async (path: string) => {
+      await window.jupyterapp.commands.execute('docmanager:open', { path });
+    }, sourcePath);
+    expect(await page.activity.activateTab('index.ts')).toBe(true);
+  };
+
+  const executeLoad = async () => {
+    return page.evaluate((id: string) => {
+      return window.jupyterapp.commands.execute(id);
+    }, LOAD_COMMAND);
+  };
+
+  await waitForCommand(LOAD_COMMAND);
+  await openSourceInEditor();
+  const firstLoadResult = await executeLoad();
+  expect(firstLoadResult.ok).toBe(true);
+  expect(firstLoadResult.status).toBe('loaded');
+
+  await waitForCommand(DYNAMIC_SETTINGS_PERSIST_TEST_SET_COMMAND);
+  const setResult = await page.evaluate(
+    ({ commandId, enabled }) => {
+      return window.jupyterapp.commands.execute(commandId, { enabled });
+    },
+    { commandId: DYNAMIC_SETTINGS_PERSIST_TEST_SET_COMMAND, enabled: true }
+  );
+  expect(setResult).toBe(true);
+
+  await page.contents.uploadContent(
+    DYNAMIC_SETTINGS_PERSIST_TEST_SCHEMA_UPDATED,
+    'text',
+    schemaPath
+  );
+
+  const loadAfterSchemaChange = await executeLoad();
+  expect(loadAfterSchemaChange.ok).toBe(true);
+  expect(loadAfterSchemaChange.status).toBe('loaded');
+  expect(loadAfterSchemaChange.pluginIds).toContain(
+    DYNAMIC_SETTINGS_PERSIST_TEST_PLUGIN_ID
   );
 });
 

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -269,6 +269,52 @@ const DYNAMIC_SETTINGS_RELOAD_TEST_SCHEMA = JSON.stringify(
   null,
   2
 );
+const DYNAMIC_SETTINGS_PERSIST_TEST_PLUGIN_ID =
+  'dynamic-settings-persist-test:plugin';
+const DYNAMIC_SETTINGS_PERSIST_TEST_SET_COMMAND =
+  'dynamic-settings-persist-test:set-enabled';
+const DYNAMIC_SETTINGS_PERSIST_TEST_GET_COMMAND =
+  'dynamic-settings-persist-test:get-enabled';
+const DYNAMIC_SETTINGS_PERSIST_TEST_SOURCE = `
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
+
+const plugin = {
+  id: '${DYNAMIC_SETTINGS_PERSIST_TEST_PLUGIN_ID}',
+  autoStart: true,
+  requires: [ISettingRegistry],
+  activate: async (app, settingRegistry) => {
+    const settings = await settingRegistry.load(
+      '${DYNAMIC_SETTINGS_PERSIST_TEST_PLUGIN_ID}'
+    );
+    app.commands.addCommand('${DYNAMIC_SETTINGS_PERSIST_TEST_SET_COMMAND}', {
+      execute: async args => {
+        const enabled = args.enabled === true;
+        await settings.set('enabled', enabled);
+        return enabled;
+      }
+    });
+    app.commands.addCommand('${DYNAMIC_SETTINGS_PERSIST_TEST_GET_COMMAND}', {
+      execute: () => settings.get('enabled').composite
+    });
+  }
+};
+
+export default plugin;
+`;
+const DYNAMIC_SETTINGS_PERSIST_TEST_SCHEMA = JSON.stringify(
+  {
+    title: 'Dynamic settings persist test schema',
+    type: 'object',
+    properties: {
+      enabled: {
+        type: 'boolean',
+        default: false
+      }
+    }
+  },
+  null,
+  2
+);
 
 async function openSidebarPanel(
   page: IJupyterLabPageFixture,
@@ -1942,6 +1988,93 @@ test('removes settings entry when reloading plugin without schema', async ({
   );
   expect(secondDynamicSettingsState.hasDynamicSchema).toBe(false);
   expect(secondDynamicSettingsState.hasRegistryPlugin).toBe(false);
+});
+
+test('persists dynamic plugin settings after page refresh', async ({
+  page,
+  tmpPath
+}) => {
+  const projectRoot = `${tmpPath}/dynamic-settings-persist-test`;
+  const sourcePath = `${projectRoot}/index.ts`;
+  const schemaPath = `${projectRoot}/plugin.json`;
+
+  await page.contents.uploadContent(
+    DYNAMIC_SETTINGS_PERSIST_TEST_SOURCE,
+    'text',
+    sourcePath
+  );
+  await page.contents.uploadContent(
+    DYNAMIC_SETTINGS_PERSIST_TEST_SCHEMA,
+    'text',
+    schemaPath
+  );
+  await page.goto();
+
+  await page.filebrowser.open(sourcePath);
+  expect(await page.activity.activateTab('index.ts')).toBe(true);
+
+  await page.waitForCondition(() =>
+    page.evaluate((id: string) => {
+      return window.jupyterapp.commands.hasCommand(id);
+    }, LOAD_COMMAND)
+  );
+
+  const firstLoadResult = await page.evaluate((id: string) => {
+    return window.jupyterapp.commands.execute(id);
+  }, LOAD_COMMAND);
+  expect(firstLoadResult.ok).toBe(true);
+  expect(firstLoadResult.status).toBe('loaded');
+  expect(firstLoadResult.pluginIds).toContain(
+    DYNAMIC_SETTINGS_PERSIST_TEST_PLUGIN_ID
+  );
+
+  await page.waitForCondition(() =>
+    page.evaluate((id: string) => {
+      return window.jupyterapp.commands.hasCommand(id);
+    }, DYNAMIC_SETTINGS_PERSIST_TEST_SET_COMMAND)
+  );
+
+  const setResult = await page.evaluate(
+    ({ commandId, enabled }) => {
+      return window.jupyterapp.commands.execute(commandId, { enabled });
+    },
+    { commandId: DYNAMIC_SETTINGS_PERSIST_TEST_SET_COMMAND, enabled: true }
+  );
+  expect(setResult).toBe(true);
+
+  const firstValue = await page.evaluate((commandId: string) => {
+    return window.jupyterapp.commands.execute(commandId);
+  }, DYNAMIC_SETTINGS_PERSIST_TEST_GET_COMMAND);
+  expect(firstValue).toBe(true);
+
+  await page.goto();
+
+  await page.filebrowser.open(sourcePath);
+  await page.waitForCondition(() =>
+    page.evaluate((id: string) => {
+      return window.jupyterapp.commands.hasCommand(id);
+    }, LOAD_COMMAND)
+  );
+
+  const secondLoadResult = await page.evaluate((id: string) => {
+    return window.jupyterapp.commands.execute(id);
+  }, LOAD_COMMAND);
+  expect(secondLoadResult.ok).toBe(true);
+  expect(secondLoadResult.status).toBe('loaded');
+  expect(secondLoadResult.pluginIds).toContain(
+    DYNAMIC_SETTINGS_PERSIST_TEST_PLUGIN_ID
+  );
+
+  await page.waitForCondition(() =>
+    page.evaluate((id: string) => {
+      return window.jupyterapp.commands.hasCommand(id);
+    }, DYNAMIC_SETTINGS_PERSIST_TEST_GET_COMMAND)
+  );
+
+  const secondValue = await page.evaluate((commandId: string) => {
+    return window.jupyterapp.commands.execute(commandId);
+  }, DYNAMIC_SETTINGS_PERSIST_TEST_GET_COMMAND);
+  expect(secondValue).toBe(true);
 });
 
 test('exports active extension folder as a zip archive', async ({

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -1988,8 +1988,7 @@ test('persists dynamic plugin settings in browser storage', async ({
       (pluginId: string) => {
         const key = `plugin-playground:dynamic-settings:${pluginId}`;
         return (
-          window.localStorage.getItem(key) ??
-          window.sessionStorage.getItem(key)
+          window.localStorage.getItem(key) ?? window.sessionStorage.getItem(key)
         );
       },
       DYNAMIC_SETTINGS_PERSIST_TEST_PLUGIN_ID

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -12,8 +12,6 @@ const EXPORT_COMMAND = 'plugin-playground:export-as-extension';
 const SHARE_COMMAND = 'plugin-playground:share-via-link';
 const OPEN_PACKAGES_REFERENCE_COMMAND = 'plugin-playground:open-js-explorer';
 const INTERNAL_CONTEXT_INFO_COMMAND = '__internal:context-menu-info';
-const INTERNAL_DYNAMIC_SETTINGS_STATE_COMMAND =
-  '__internal:plugin-playground-dynamic-settings-state';
 const CREATE_FILE_COMMAND = 'plugin-playground:create-new-plugin';
 const CREATE_FILE_WITH_AI_COMMAND =
   'plugin-playground:create-new-plugin-with-ai';
@@ -242,33 +240,6 @@ const CSS_IMPORT_TEST_PACKAGE_JSON_WITH_STYLE = JSON.stringify(
   2
 );
 
-const DYNAMIC_SETTINGS_RELOAD_TEST_PLUGIN_ID =
-  'dynamic-settings-reload-test:plugin';
-const DYNAMIC_SETTINGS_RELOAD_TEST_SOURCE = `
-const plugin = {
-  id: '${DYNAMIC_SETTINGS_RELOAD_TEST_PLUGIN_ID}',
-  autoStart: true,
-  activate: () => {
-    // no-op
-  }
-};
-
-export default plugin;
-`;
-const DYNAMIC_SETTINGS_RELOAD_TEST_SCHEMA = JSON.stringify(
-  {
-    title: 'Dynamic settings reload test schema',
-    type: 'object',
-    properties: {
-      enabled: {
-        type: 'boolean',
-        default: true
-      }
-    }
-  },
-  null,
-  2
-);
 const DYNAMIC_SETTINGS_PERSIST_TEST_PLUGIN_ID =
   'dynamic-settings-persist-test:plugin';
 const DYNAMIC_SETTINGS_PERSIST_TEST_SET_COMMAND =
@@ -1913,84 +1884,7 @@ test('rolls back CSS changes when plugin schema parsing fails', async ({
   ).resolves.toBe(CSS_IMPORT_TEST_COLOR);
 });
 
-test('removes settings entry when reloading plugin without schema', async ({
-  page,
-  tmpPath
-}) => {
-  const projectRoot = `${tmpPath}/dynamic-settings-reload-test`;
-  const sourcePath = `${projectRoot}/index.ts`;
-  const schemaPath = `${projectRoot}/plugin.json`;
-
-  await page.contents.uploadContent(
-    DYNAMIC_SETTINGS_RELOAD_TEST_SOURCE,
-    'text',
-    sourcePath
-  );
-  await page.contents.uploadContent(
-    DYNAMIC_SETTINGS_RELOAD_TEST_SCHEMA,
-    'text',
-    schemaPath
-  );
-  await page.goto();
-
-  await page.filebrowser.open(sourcePath);
-  expect(await page.activity.activateTab('index.ts')).toBe(true);
-
-  await page.waitForCondition(() =>
-    page.evaluate((id: string) => {
-      return window.jupyterapp.commands.hasCommand(id);
-    }, LOAD_COMMAND)
-  );
-
-  const firstLoadResult = await page.evaluate((id: string) => {
-    return window.jupyterapp.commands.execute(id);
-  }, LOAD_COMMAND);
-  expect(firstLoadResult.ok).toBe(true);
-  expect(firstLoadResult.status).toBe('loaded');
-  expect(firstLoadResult.pluginIds).toContain(
-    DYNAMIC_SETTINGS_RELOAD_TEST_PLUGIN_ID
-  );
-  const firstDynamicSettingsState = await page.evaluate(
-    ({ commandId, pluginId }) => {
-      return window.jupyterapp.commands.execute(commandId, { pluginId });
-    },
-    {
-      commandId: INTERNAL_DYNAMIC_SETTINGS_STATE_COMMAND,
-      pluginId: DYNAMIC_SETTINGS_RELOAD_TEST_PLUGIN_ID
-    }
-  );
-  expect(firstDynamicSettingsState.hasDynamicSchema).toBe(true);
-  expect(firstDynamicSettingsState.hasRegistryPlugin).toBe(true);
-
-  await page.evaluate(async (path: string) => {
-    await window.jupyterapp.serviceManager.contents.delete(path);
-  }, schemaPath);
-  await expect(page.contents.fileExists(schemaPath)).resolves.toBe(false);
-
-  expect(await page.activity.activateTab('index.ts')).toBe(true);
-  const secondLoadResult = await page.evaluate((id: string) => {
-    return window.jupyterapp.commands.execute(id);
-  }, LOAD_COMMAND);
-  expect(secondLoadResult.ok).toBe(true);
-  expect(secondLoadResult.status).toBe('loaded');
-  expect(secondLoadResult.pluginIds).toContain(
-    DYNAMIC_SETTINGS_RELOAD_TEST_PLUGIN_ID
-  );
-
-  const secondDynamicSettingsState = await page.evaluate(
-    ({ commandId, pluginId }) => {
-      return window.jupyterapp.commands.execute(commandId, { pluginId });
-    },
-    {
-      commandId: INTERNAL_DYNAMIC_SETTINGS_STATE_COMMAND,
-      pluginId: DYNAMIC_SETTINGS_RELOAD_TEST_PLUGIN_ID
-    }
-  );
-  expect(secondDynamicSettingsState.hasDynamicSchema).toBe(false);
-  expect(secondDynamicSettingsState.hasRegistryPlugin).toBe(false);
-});
-
-test('persists dynamic plugin settings after page refresh', async ({
+test('persists dynamic plugin settings in browser storage', async ({
   page,
   tmpPath
 }) => {
@@ -2011,37 +1905,7 @@ test('persists dynamic plugin settings after page refresh', async ({
   await page.goto();
 
   const openSourceInEditor = async () => {
-    const openResult = await page.evaluate(async (pathToOpen: string) => {
-      type EditorWidgetShape = {
-        id?: string;
-        context?: { ready?: Promise<void>; path?: string };
-      };
-      const widget = (await window.jupyterapp.commands.execute(
-        'docmanager:open',
-        {
-          path: pathToOpen,
-          factory: 'Editor'
-        }
-      )) as EditorWidgetShape | null;
-      await widget?.context?.ready;
-      if (widget?.id) {
-        window.jupyterapp.shell.activateById(widget.id);
-        await new Promise<void>(resolve =>
-          window.requestAnimationFrame(() => resolve())
-        );
-      }
-      return {
-        openedPath: widget?.context?.path ?? null,
-        widgetId: widget?.id ?? null
-      };
-    }, sourcePath);
-
-    expect(openResult.openedPath).toBe(sourcePath);
-    if (openResult.widgetId) {
-      await page.waitForFunction((widgetId: string) => {
-        return window.jupyterapp.shell.currentWidget?.id === widgetId;
-      }, openResult.widgetId);
-    }
+    await page.filebrowser.open(sourcePath);
     expect(await page.activity.activateTab('index.ts')).toBe(true);
   };
 
@@ -2081,34 +1945,24 @@ test('persists dynamic plugin settings after page refresh', async ({
   }, DYNAMIC_SETTINGS_PERSIST_TEST_GET_COMMAND);
   expect(firstValue).toBe(true);
 
-  await page.reload({ waitForIsReady: false });
-  await openSourceInEditor();
+  const storedDynamicSetting = await page.evaluate((pluginId: string) => {
+    const key = `plugin-playground:dynamic-settings:${pluginId}`;
+    return (
+      window.localStorage.getItem(key) ?? window.sessionStorage.getItem(key)
+    );
+  }, DYNAMIC_SETTINGS_PERSIST_TEST_PLUGIN_ID);
+  expect(storedDynamicSetting).not.toBeNull();
 
-  await page.waitForCondition(() =>
-    page.evaluate((id: string) => {
-      return window.jupyterapp.commands.hasCommand(id);
-    }, LOAD_COMMAND)
-  );
-
-  const secondLoadResult = await page.evaluate((id: string) => {
-    return window.jupyterapp.commands.execute(id);
-  }, LOAD_COMMAND);
-  expect(secondLoadResult.ok).toBe(true);
-  expect(secondLoadResult.status).toBe('loaded');
-  expect(secondLoadResult.pluginIds).toContain(
-    DYNAMIC_SETTINGS_PERSIST_TEST_PLUGIN_ID
-  );
-
-  await page.waitForCondition(() =>
-    page.evaluate((id: string) => {
-      return window.jupyterapp.commands.hasCommand(id);
-    }, DYNAMIC_SETTINGS_PERSIST_TEST_GET_COMMAND)
-  );
-
-  const secondValue = await page.evaluate((commandId: string) => {
-    return window.jupyterapp.commands.execute(commandId);
-  }, DYNAMIC_SETTINGS_PERSIST_TEST_GET_COMMAND);
-  expect(secondValue).toBe(true);
+  const parsedStoredDynamicSetting = JSON.parse(storedDynamicSetting ?? '{}') as
+    | {
+        raw?: string;
+        schema?: { properties?: { enabled?: { default?: boolean } } };
+      }
+    | undefined;
+  expect(parsedStoredDynamicSetting?.raw).toContain('"enabled": true');
+  expect(
+    parsedStoredDynamicSetting?.schema?.properties?.enabled?.default
+  ).toBe(false);
 });
 
 test('exports active extension folder as a zip archive', async ({

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -2010,8 +2010,42 @@ test('persists dynamic plugin settings after page refresh', async ({
   );
   await page.goto();
 
-  await page.filebrowser.open(sourcePath);
-  expect(await page.activity.activateTab('index.ts')).toBe(true);
+  const openSourceInEditor = async () => {
+    const openResult = await page.evaluate(async (pathToOpen: string) => {
+      type EditorWidgetShape = {
+        id?: string;
+        context?: { ready?: Promise<void>; path?: string };
+      };
+      const widget = (await window.jupyterapp.commands.execute(
+        'docmanager:open',
+        {
+          path: pathToOpen,
+          factory: 'Editor'
+        }
+      )) as EditorWidgetShape | null;
+      await widget?.context?.ready;
+      if (widget?.id) {
+        window.jupyterapp.shell.activateById(widget.id);
+        await new Promise<void>(resolve =>
+          window.requestAnimationFrame(() => resolve())
+        );
+      }
+      return {
+        openedPath: widget?.context?.path ?? null,
+        widgetId: widget?.id ?? null
+      };
+    }, sourcePath);
+
+    expect(openResult.openedPath).toBe(sourcePath);
+    if (openResult.widgetId) {
+      await page.waitForFunction((widgetId: string) => {
+        return window.jupyterapp.shell.currentWidget?.id === widgetId;
+      }, openResult.widgetId);
+    }
+    expect(await page.activity.activateTab('index.ts')).toBe(true);
+  };
+
+  await openSourceInEditor();
 
   await page.waitForCondition(() =>
     page.evaluate((id: string) => {
@@ -2047,9 +2081,9 @@ test('persists dynamic plugin settings after page refresh', async ({
   }, DYNAMIC_SETTINGS_PERSIST_TEST_GET_COMMAND);
   expect(firstValue).toBe(true);
 
-  await page.goto();
+  await page.reload({ waitForIsReady: false });
+  await openSourceInEditor();
 
-  await page.filebrowser.open(sourcePath);
   await page.waitForCondition(() =>
     page.evaluate((id: string) => {
       return window.jupyterapp.commands.hasCommand(id);

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -12,6 +12,8 @@ const EXPORT_COMMAND = 'plugin-playground:export-as-extension';
 const SHARE_COMMAND = 'plugin-playground:share-via-link';
 const OPEN_PACKAGES_REFERENCE_COMMAND = 'plugin-playground:open-js-explorer';
 const INTERNAL_CONTEXT_INFO_COMMAND = '__internal:context-menu-info';
+const INTERNAL_DYNAMIC_SETTINGS_STATE_COMMAND =
+  '__internal:plugin-playground-dynamic-settings-state';
 const CREATE_FILE_COMMAND = 'plugin-playground:create-new-plugin';
 const CREATE_FILE_WITH_AI_COMMAND =
   'plugin-playground:create-new-plugin-with-ai';
@@ -234,6 +236,34 @@ const CSS_IMPORT_TEST_PACKAGE_JSON_WITH_STYLE = JSON.stringify(
     style: 'style/index.css',
     jupyterlab: {
       extension: true
+    }
+  },
+  null,
+  2
+);
+
+const DYNAMIC_SETTINGS_RELOAD_TEST_PLUGIN_ID =
+  'dynamic-settings-reload-test:plugin';
+const DYNAMIC_SETTINGS_RELOAD_TEST_SOURCE = `
+const plugin = {
+  id: '${DYNAMIC_SETTINGS_RELOAD_TEST_PLUGIN_ID}',
+  autoStart: true,
+  activate: () => {
+    // no-op
+  }
+};
+
+export default plugin;
+`;
+const DYNAMIC_SETTINGS_RELOAD_TEST_SCHEMA = JSON.stringify(
+  {
+    title: 'Dynamic settings reload test schema',
+    type: 'object',
+    properties: {
+      enabled: {
+        type: 'boolean',
+        default: true
+      }
     }
   },
   null,
@@ -1835,6 +1865,83 @@ test('rolls back CSS changes when plugin schema parsing fails', async ({
       return window.getComputedStyle(marker).backgroundColor;
     }, CSS_IMPORT_TEST_MARKER_ID)
   ).resolves.toBe(CSS_IMPORT_TEST_COLOR);
+});
+
+test('removes settings entry when reloading plugin without schema', async ({
+  page,
+  tmpPath
+}) => {
+  const projectRoot = `${tmpPath}/dynamic-settings-reload-test`;
+  const sourcePath = `${projectRoot}/index.ts`;
+  const schemaPath = `${projectRoot}/plugin.json`;
+
+  await page.contents.uploadContent(
+    DYNAMIC_SETTINGS_RELOAD_TEST_SOURCE,
+    'text',
+    sourcePath
+  );
+  await page.contents.uploadContent(
+    DYNAMIC_SETTINGS_RELOAD_TEST_SCHEMA,
+    'text',
+    schemaPath
+  );
+  await page.goto();
+
+  await page.filebrowser.open(sourcePath);
+  expect(await page.activity.activateTab('index.ts')).toBe(true);
+
+  await page.waitForCondition(() =>
+    page.evaluate((id: string) => {
+      return window.jupyterapp.commands.hasCommand(id);
+    }, LOAD_COMMAND)
+  );
+
+  const firstLoadResult = await page.evaluate((id: string) => {
+    return window.jupyterapp.commands.execute(id);
+  }, LOAD_COMMAND);
+  expect(firstLoadResult.ok).toBe(true);
+  expect(firstLoadResult.status).toBe('loaded');
+  expect(firstLoadResult.pluginIds).toContain(
+    DYNAMIC_SETTINGS_RELOAD_TEST_PLUGIN_ID
+  );
+  const firstDynamicSettingsState = await page.evaluate(
+    ({ commandId, pluginId }) => {
+      return window.jupyterapp.commands.execute(commandId, { pluginId });
+    },
+    {
+      commandId: INTERNAL_DYNAMIC_SETTINGS_STATE_COMMAND,
+      pluginId: DYNAMIC_SETTINGS_RELOAD_TEST_PLUGIN_ID
+    }
+  );
+  expect(firstDynamicSettingsState.hasDynamicSchema).toBe(true);
+  expect(firstDynamicSettingsState.hasRegistryPlugin).toBe(true);
+
+  await page.evaluate(async (path: string) => {
+    await window.jupyterapp.serviceManager.contents.delete(path);
+  }, schemaPath);
+  await expect(page.contents.fileExists(schemaPath)).resolves.toBe(false);
+
+  expect(await page.activity.activateTab('index.ts')).toBe(true);
+  const secondLoadResult = await page.evaluate((id: string) => {
+    return window.jupyterapp.commands.execute(id);
+  }, LOAD_COMMAND);
+  expect(secondLoadResult.ok).toBe(true);
+  expect(secondLoadResult.status).toBe('loaded');
+  expect(secondLoadResult.pluginIds).toContain(
+    DYNAMIC_SETTINGS_RELOAD_TEST_PLUGIN_ID
+  );
+
+  const secondDynamicSettingsState = await page.evaluate(
+    ({ commandId, pluginId }) => {
+      return window.jupyterapp.commands.execute(commandId, { pluginId });
+    },
+    {
+      commandId: INTERNAL_DYNAMIC_SETTINGS_STATE_COMMAND,
+      pluginId: DYNAMIC_SETTINGS_RELOAD_TEST_PLUGIN_ID
+    }
+  );
+  expect(secondDynamicSettingsState.hasDynamicSchema).toBe(false);
+  expect(secondDynamicSettingsState.hasRegistryPlugin).toBe(false);
 });
 
 test('exports active extension folder as a zip archive', async ({


### PR DESCRIPTION
Fixes #8 

This PR fixes the dynamic settings state during reloads by clearing stale registry entries when the schema is removed and rolling back only plugin IDs that were actually changed.





