### PR TITLE
Fix server extension loading when `package.json` is missing

### DIFF
--- a/jupyterlab_plugin_playground/__init__.py
+++ b/jupyterlab_plugin_playground/__init__.py
@@ -1,18 +1,15 @@
 
-import json
 import shutil
 from pathlib import Path
 
 HERE = Path(__file__).parent.resolve()
 EXAMPLES = HERE / "extension-examples"
-
-with (HERE / "labextension" / "package.json").open() as fid:
-    data = json.load(fid)
+LABEXTENSION_NAME = "@jupyterlab/plugin-playground"
 
 def _jupyter_labextension_paths():
     return [{
         "src": "labextension",
-        "dest": data["name"]
+        "dest": LABEXTENSION_NAME
     }]
 
 


### PR DESCRIPTION
Fixes #222 

This removes the import-time read of `labextension/package.json` in `jupyterlab_plugin_playground/__init__.py` and uses a fixed `labextension` name instead, so the server extension loads reliably across install layouts.