### PR TITLE
Add “Ask AI” action for JS log errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ Plugin Playground supports AI-assisted extension prototyping in both JupyterLite
 - [JupyterLite AI documentation](https://jupyterlite-ai.readthedocs.io/en/latest/)
 - [Plugin authoring skill for agents](_agents/skills/plugin-authoring/SKILL.md)
 
+### JS Logs Ask AI (Optional)
+
+Plugin Playground can add an `Ask AI` button to JS Logs entries so you can send error text to JupyterLite AI chat for debugging context. This is disabled by default and can be enabled with the `askAILogEntryActionEnabled` setting. When enabled, the button appears only on `error`/`critical` entries that include text content.
+
 ### Command Insert Modes (Default + AI Prompt)
 
 In the `Commands` tab, each command row includes a split `+` action and a mode dropdown:
@@ -290,6 +294,8 @@ Runtime import resolution order is:
 
 `commandInsertDefaultMode` sets the default behavior for the `+` action in the Commands tab (`insert` for direct insertion or `ai` for AI-assisted prompt flow).
 
+`askAILogEntryActionEnabled` enables the optional `Ask AI` button for JS Logs `error`/`critical` entries with text content (disabled by default).
+
 `shareFolderSelectionDialogMode` controls when folder sharing prompts for file selection (`always`, `auto-excluded-or-limit`, `limit-only`).
 
 ![Plugin Playground settings showing command insert default mode](docs/images/readme/settings-command-insert-default-mode.png)
@@ -309,6 +315,7 @@ Example:
   requirejsCDN: 'https://cdn.jsdelivr.net/npm/',
   loadOnSave: false,
   commandInsertDefaultMode: 'insert',
+  askAILogEntryActionEnabled: false,
   urls: ['https://gist.githubusercontent.com/.../raw/plugin.ts'],
   plugins: [
     "{ \n\

--- a/README.md
+++ b/README.md
@@ -172,9 +172,9 @@ Plugin Playground supports AI-assisted extension prototyping in both JupyterLite
 - [JupyterLite AI documentation](https://jupyterlite-ai.readthedocs.io/en/latest/)
 - [Plugin authoring skill for agents](_agents/skills/plugin-authoring/SKILL.md)
 
-### JS Logs Ask AI (Optional)
+### JS Logs Ask AI
 
-Plugin Playground can add an `Ask AI` button to JS Logs entries so you can send error text to JupyterLite AI chat for debugging context. This is disabled by default and can be enabled with the `askAILogEntryActionEnabled` setting. When enabled, the button appears only on `error`/`critical` entries that include text content.
+Plugin Playground adds an `Ask AI` button to JS Logs entries so you can send error text to JupyterLite AI chat for debugging context. The button appears only on `error`/`critical` entries that include text content, and only when JupyterLite AI is available.
 
 ### Command Insert Modes (Default + AI Prompt)
 
@@ -294,8 +294,6 @@ Runtime import resolution order is:
 
 `commandInsertDefaultMode` sets the default behavior for the `+` action in the Commands tab (`insert` for direct insertion or `ai` for AI-assisted prompt flow).
 
-`askAILogEntryActionEnabled` enables the optional `Ask AI` button for JS Logs `error`/`critical` entries with text content (disabled by default).
-
 `shareFolderSelectionDialogMode` controls when folder sharing prompts for file selection (`always`, `auto-excluded-or-limit`, `limit-only`).
 
 ![Plugin Playground settings showing command insert default mode](docs/images/readme/settings-command-insert-default-mode.png)
@@ -315,7 +313,6 @@ Example:
   requirejsCDN: 'https://cdn.jsdelivr.net/npm/',
   loadOnSave: false,
   commandInsertDefaultMode: 'insert',
-  askAILogEntryActionEnabled: false,
   urls: ['https://gist.githubusercontent.com/.../raw/plugin.ts'],
   plugins: [
     "{ \n\

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Plugin Playground supports AI-assisted extension prototyping in both JupyterLite
 
 ### JS Logs Ask AI
 
-Plugin Playground adds an `Ask AI` button to JS Logs entries so you can send error text to JupyterLite AI chat for debugging context. The button appears only on `error`/`critical` entries that include text content, and only when JupyterLite AI is available.
+Plugin Playground adds an `Ask AI` button to JS Logs entries so you can send error text to JupyterLite AI chat for debugging context. The button appears only on `error`/`critical` entries that include text content, and only when JupyterLite AI is available and a provider is configured.
 
 ### Command Insert Modes (Default + AI Prompt)
 

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   # additional packages for demos
   # - ipywidgets
   - jupyterlab-lsp
-  - jupyterlab-js-logs>=1.2,<2
+  - jupyterlab-js-logs>=1.3,<2
   - jupyterlab-tour>=4,<5
   # use the same AI package in Binder and JupyterLite deployments
   - jupyterlite-ai>=0.15,<1

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   # additional packages for demos
   # - ipywidgets
   - jupyterlab-lsp
-  - jupyterlab-js-logs>=1.3,<2
+  - jupyterlab-js-logs>=1.3.1,<2
   - jupyterlab-tour>=4,<5
   # use the same AI package in Binder and JupyterLite deployments
   - jupyterlite-ai>=0.15,<1

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - myst-parser
   - ipywidgets>=8.0,<9
   - jupyterlab>=4.0.0,<5
-  - jupyterlab-js-logs>=1.2,<2
+  - jupyterlab-js-logs>=1.3,<2
   - jupyterlab-tour>=4,<5
   - jupyterlab-language-pack-fr-FR
   - jupyterlab-language-pack-zh-CN

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - myst-parser
   - ipywidgets>=8.0,<9
   - jupyterlab>=4.0.0,<5
-  - jupyterlab-js-logs>=1.3,<2
+  - jupyterlab-js-logs>=1.3.1,<2
   - jupyterlab-tour>=4,<5
   - jupyterlab-language-pack-fr-FR
   - jupyterlab-language-pack-zh-CN

--- a/package.json
+++ b/package.json
@@ -136,6 +136,11 @@
         "extension": true,
         "outputDir": "jupyterlab_plugin_playground/labextension",
         "schemaDir": "schema",
+        "sharedPackages": {
+            "jupyterlab-js-logs": {
+                "singleton": true
+            }
+        },
         "disabledExtensions": [
             "jupyterlab-tour:default-tours"
         ]

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "@jupyterlab/filebrowser": "^4.5.5",
         "@jupyterlab/fileeditor": "^4.5.5",
         "@jupyterlab/settingregistry": "^4.5.5",
-        "jupyterlab-js-logs": "^1.2.0",
+        "jupyterlab-js-logs": "^1.3.0",
         "raw-loader": "^4.0.2",
         "requirejs": "^2.3.6",
         "semver": "^7.7.4",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "@jupyterlab/filebrowser": "^4.5.5",
         "@jupyterlab/fileeditor": "^4.5.5",
         "@jupyterlab/settingregistry": "^4.5.5",
-        "jupyterlab-js-logs": "^1.3.0",
+        "jupyterlab-js-logs": "^1.3.1",
         "raw-loader": "^4.0.2",
         "requirejs": "^2.3.6",
         "semver": "^7.7.4",

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -44,12 +44,6 @@
       "type": "string",
       "enum": ["insert", "ai"]
     },
-    "askAILogEntryActionEnabled": {
-      "title": "Enable \"Ask AI\" in JS Logs",
-      "description": "Whether to show an \"Ask AI\" button on error/critical JS log entries with text content.",
-      "default": false,
-      "type": "boolean"
-    },
     "shareFolderSelectionDialogMode": {
       "title": "Show file selection dialog on folder share",
       "description": "Control when folder sharing opens the file-selection dialog. Use \"always\" to always ask, \"auto-excluded-or-limit\" to ask when files are auto-excluded or the URL size limit is hit, or \"limit-only\" to ask only when the URL size limit is hit.",

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -44,6 +44,12 @@
       "type": "string",
       "enum": ["insert", "ai"]
     },
+    "askAILogEntryActionEnabled": {
+      "title": "Enable \"Ask AI\" in JS Logs",
+      "description": "Whether to show an \"Ask AI\" button on error/critical JS log entries with text content.",
+      "default": false,
+      "type": "boolean"
+    },
     "shareFolderSelectionDialogMode": {
       "title": "Show file selection dialog on folder share",
       "description": "Control when folder sharing opens the file-selection dialog. Use \"always\" to always ask, \"auto-excluded-or-limit\" to ask when files are auto-excluded or the URL size limit is hit, or \"limit-only\" to ask only when the URL size limit is hit.",

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,6 @@ import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
 
 import { ILauncher } from '@jupyterlab/launcher';
 import { IMainMenu } from '@jupyterlab/mainmenu';
-import { IChatTracker } from '@jupyter/chat';
 
 import {
   IFrame,
@@ -191,6 +190,41 @@ interface ILayoutHideSelection {
   hideStatusBar: boolean;
 }
 
+/**
+ * Serialized log output payload passed by the js-logs action API.
+ */
+type ISerializedLogOutput = Record<string, unknown>;
+
+/**
+ * Log entry payload received by the js-logs entry action callback.
+ */
+interface ILogEntryActionMessage {
+  source: string;
+  entryIndex: number;
+  level: string;
+  timestamp: Date | null;
+  text: string;
+  output: ISerializedLogOutput;
+}
+
+/**
+ * Action definition registered with the js-logs entry action registry.
+ */
+interface ILogEntryAction {
+  id: string;
+  label: string;
+  caption?: string;
+  isVisible?: (message: ILogEntryActionMessage) => boolean;
+  execute: (message: ILogEntryActionMessage) => void | Promise<void>;
+}
+
+/**
+ * Registry interface exposed by js-logs for entry-level actions.
+ */
+interface ILogEntryActionRegistry {
+  register(action: ILogEntryAction): { dispose: () => void };
+}
+
 const PLUGIN_TEMPLATE = `import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin,
@@ -299,16 +333,21 @@ const LOAD_ON_SAVE_TOGGLE_TOOLBAR_ITEM = 'plugin-playground-load-on-save';
 const LOAD_ON_SAVE_CHECKBOX_LABEL = 'Run on save';
 const LOAD_ON_SAVE_SETTING = 'loadOnSave';
 const COMMAND_INSERT_DEFAULT_MODE_SETTING = 'commandInsertDefaultMode';
+const ASK_AI_LOG_ENTRY_ACTION_ENABLED_SETTING = 'askAILogEntryActionEnabled';
 const LOAD_ON_SAVE_ENABLED_DESCRIPTION =
   'Toggle auto-loading this file as an extension on save';
 const LOAD_ON_SAVE_DISABLED_DESCRIPTION =
   'Auto load on save is available for JavaScript and TypeScript files';
-const JUPYTERLITE_AI_OPEN_CHAT_COMMAND = '@jupyterlite/ai:open-chat';
+const JUPYTERLITE_AI_OPEN_OR_REVEAL_CHAT_COMMAND =
+  '@jupyterlite/ai:open-or-reveal-chat';
 const JUPYTERLITE_AI_OPEN_SETTINGS_COMMAND = '@jupyterlite/ai:open-settings';
-const JUPYTERLITE_AI_CHAT_PANEL_ID = '@jupyterlite/ai:chat-panel';
 const JUPYTERLITE_AI_INSTALL_HINT =
   'JupyterLite AI is unavailable. Install the jupyterlite-ai extension and reload the application.';
 const JUPYTERLITE_AI_PROVIDER_SETUP_HINT = 'No AI provider configured.';
+const JS_LOGS_ENTRY_ACTION_REGISTRY_TOKEN_NAME =
+  'jupyterlab-js-logs:ILogEntryActionRegistry';
+const ASK_AI_LOG_ENTRY_ACTION_ID = 'plugin-playground:ask-ai-log-entry';
+const LOG_ENTRY_PROMPT_MAX_OUTPUT_LENGTH = 8000;
 type JupyterLiteAIErrorCode = 'install-unavailable' | 'provider-setup-required';
 type JupyterLiteAIChatOpenStatus =
   | 'opened'
@@ -376,7 +415,6 @@ class PluginPlayground {
     protected fileBrowserFactory: IFileBrowserFactory | null,
     launcher: ILauncher | null,
     protected documentManager: IDocumentManager | null,
-    protected chatTracker: IChatTracker | null,
     protected settings: ISettingRegistry.ISettings,
     protected requirejs: IRequireJS,
     toolbarWidgetRegistry: IToolbarWidgetRegistry,
@@ -932,9 +970,11 @@ class PluginPlayground {
         for (const refresh of this._loadOnSaveToggleRefreshers) {
           refresh();
         }
+        void this._updateAskAILogEntryActionRegistration();
       });
 
       this._setupLogsBadge();
+      void this._updateAskAILogEntryActionRegistration();
     });
   }
 
@@ -3370,37 +3410,34 @@ class PluginPlayground {
       commandArguments
     });
 
-    await this._openJupyterLiteAIChatPanel();
-
-    const inputModel = await this._requireJupyterLiteAIChatInputModel();
-    inputModel.value = prompt;
-    inputModel.focus();
-    window.requestAnimationFrame(() => {
-      const activeElement = document.activeElement;
-      if (
-        activeElement instanceof HTMLTextAreaElement ||
-        activeElement instanceof HTMLInputElement
-      ) {
-        const cursorIndex = activeElement.value.length;
-        activeElement.setSelectionRange(cursorIndex, cursorIndex);
-        activeElement.scrollTop = activeElement.scrollHeight;
-      }
-    });
+    await this._openOrRevealJupyterLiteAIChat({ input: prompt });
   }
 
-  private async _openJupyterLiteAIChatPanel(): Promise<void> {
-    if (!this.app.commands.hasCommand(JUPYTERLITE_AI_OPEN_CHAT_COMMAND)) {
+  private async _openOrRevealJupyterLiteAIChat(options?: {
+    input?: string;
+  }): Promise<void> {
+    if (!this.app.commands.hasCommand(JUPYTERLITE_AI_OPEN_OR_REVEAL_CHAT_COMMAND)) {
       throw new JupyterLiteAIError(
         'install-unavailable',
         JUPYTERLITE_AI_INSTALL_HINT
       );
     }
 
+    const args: {
+      area: 'side';
+      focus: true;
+      input?: string;
+    } = {
+      area: 'side',
+      focus: true
+    };
+    if (typeof options?.input === 'string') {
+      args.input = options.input;
+    }
+
     const openResult = await this.app.commands.execute(
-      JUPYTERLITE_AI_OPEN_CHAT_COMMAND,
-      {
-        area: 'side'
-      }
+      JUPYTERLITE_AI_OPEN_OR_REVEAL_CHAT_COMMAND,
+      args
     );
     if (openResult === false) {
       throw new JupyterLiteAIError(
@@ -3408,14 +3445,11 @@ class PluginPlayground {
         JUPYTERLITE_AI_PROVIDER_SETUP_HINT
       );
     }
-    this.app.shell.activateById(JUPYTERLITE_AI_CHAT_PANEL_ID);
   }
 
   private async _openJupyterLiteAIChatWithSetupFallback(): Promise<JupyterLiteAIChatOpenStatus> {
     try {
-      await this._openJupyterLiteAIChatPanel();
-      const inputModel = await this._requireJupyterLiteAIChatInputModel();
-      inputModel.focus();
+      await this._openOrRevealJupyterLiteAIChat();
       return 'opened';
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -3478,65 +3512,108 @@ class PluginPlayground {
     }
   }
 
-  private async _requireJupyterLiteAIChatInputModel(): Promise<{
-    value: string;
-    focus: () => void;
-  }> {
-    const chatTracker =
-      this.chatTracker ?? (await this.app.resolveOptionalService(IChatTracker));
-    if (!chatTracker) {
-      throw new JupyterLiteAIError(
-        'install-unavailable',
-        JUPYTERLITE_AI_INSTALL_HINT
-      );
+  private async _updateAskAILogEntryActionRegistration(): Promise<void> {
+    const registrationEpoch = ++this._askAILogEntryActionRegistrationEpoch;
+    this._askAILogEntryActionDisposable?.dispose();
+    this._askAILogEntryActionDisposable = null;
+
+    if (
+      this.settings.get(ASK_AI_LOG_ENTRY_ACTION_ENABLED_SETTING).composite !==
+      true
+    ) {
+      return;
     }
-
-    const maxAnimationFrameRetries = 3;
-    for (let attempt = 0; attempt <= maxAnimationFrameRetries; attempt++) {
-      const chatWidget =
-        chatTracker.currentWidget ?? chatTracker.find(() => true);
-      const inputModel = (
-        chatWidget as {
-          model?: {
-            input?: unknown;
-          };
-        } | null
-      )?.model?.input;
-      if (this._isJupyterLiteAIChatInputModel(inputModel)) {
-        return inputModel;
+    try {
+      const disposable = await this._registerAskAILogEntryAction();
+      if (registrationEpoch !== this._askAILogEntryActionRegistrationEpoch) {
+        disposable?.dispose();
+        return;
       }
-
-      if (
-        typeof window === 'undefined' ||
-        attempt === maxAnimationFrameRetries
-      ) {
-        break;
-      }
-      await new Promise<void>(resolve => {
-        window.requestAnimationFrame(() => {
-          resolve();
-        });
-      });
+      this._askAILogEntryActionDisposable = disposable;
+    } catch (error) {
+      console.warn('Failed to update js-logs Ask AI action registration.', error);
     }
-
-    throw new JupyterLiteAIError(
-      'provider-setup-required',
-      JUPYTERLITE_AI_PROVIDER_SETUP_HINT
-    );
   }
 
-  private _isJupyterLiteAIChatInputModel(candidate: unknown): candidate is {
-    value: string;
-    focus: () => void;
-  } {
-    return !!(
-      candidate &&
-      typeof candidate === 'object' &&
-      'value' in candidate &&
-      typeof candidate.value === 'string' &&
-      'focus' in candidate &&
-      typeof candidate.focus === 'function'
-    );
+  private async _registerAskAILogEntryAction(): Promise<{
+    dispose: () => void;
+  } | null> {
+    try {
+      this._populateTokenMap();
+    } catch {
+      return null;
+    }
+    const token = this._tokenMap.get(
+      JS_LOGS_ENTRY_ACTION_REGISTRY_TOKEN_NAME
+    ) as unknown as Token<ILogEntryActionRegistry> | null;
+    if (!token) {
+      return null;
+    }
+    const actionRegistry = await this.app.resolveOptionalService(token);
+    if (!actionRegistry) {
+      return null;
+    }
+
+    try {
+      return actionRegistry.register({
+        id: ASK_AI_LOG_ENTRY_ACTION_ID,
+        label: 'Ask AI',
+        caption: 'Open AI chat and include this log entry for debugging',
+        isVisible: message => {
+          const hasText = message.text.trim().length > 0;
+          if (!hasText) {
+            return false;
+          }
+          return message.level === 'error' || message.level === 'critical';
+        },
+        execute: message => {
+          void this._openAIChatForLogEntry(message);
+        }
+      });
+    } catch (error) {
+      console.warn('Failed to register js-logs Ask AI action.', error);
+      return null;
+    }
+  }
+
+  private async _openAIChatForLogEntry(
+    message: ILogEntryActionMessage
+  ): Promise<void> {
+    try {
+      const prompt = this._buildLogEntryAIPrompt(message);
+      if (!prompt) {
+        return;
+      }
+      await this._openOrRevealJupyterLiteAIChat({ input: prompt });
+    } catch (error) {
+      const aiErrorCode =
+        error instanceof JupyterLiteAIError ? error.code : null;
+      if (
+        aiErrorCode === 'provider-setup-required' ||
+        aiErrorCode === 'install-unavailable'
+      ) {
+        await this._openJupyterLiteAIChatWithSetupFallback();
+        return;
+      }
+
+      const details = error instanceof Error ? error.message : String(error);
+      Notification.warning(
+        `Could not prepare AI chat from log entry: ${details}`,
+        {
+          autoClose: 5000
+        }
+      );
+    }
+  }
+
+  private _buildLogEntryAIPrompt(message: ILogEntryActionMessage): string {
+    const rawText = message.text.trim();
+    const trimmedText =
+      rawText.length > LOG_ENTRY_PROMPT_MAX_OUTPUT_LENGTH
+        ? `${rawText.slice(0, LOG_ENTRY_PROMPT_MAX_OUTPUT_LENGTH)}\n...`
+        : rawText;
+
+    return trimmedText;
   }
 
   private _buildCommandInsertAIPrompt(options: {
@@ -3903,6 +3980,8 @@ class PluginPlayground {
     string,
     ISettingRegistry.ISchema
   >();
+  private _askAILogEntryActionRegistrationEpoch = 0;
+  private _askAILogEntryActionDisposable: { dispose: () => void } | null = null;
   private _commandInsertMode: CommandInsertMode = DEFAULT_COMMAND_INSERT_MODE;
   private _playgroundSidebar: SidePanel | null = null;
   private _tokenSidebar: TokenSidebar | null = null;
@@ -3929,8 +4008,7 @@ const mainPlugin: JupyterFrontEndPlugin<IPluginPlayground> = {
     IFileBrowserFactory,
     ILauncher,
     IDocumentManager,
-    ILogConsoleTracker,
-    IChatTracker
+    ILogConsoleTracker
   ],
   activate: (
     app: JupyterFrontEnd,
@@ -3942,8 +4020,7 @@ const mainPlugin: JupyterFrontEndPlugin<IPluginPlayground> = {
     fileBrowserFactory: IFileBrowserFactory | null,
     launcher: ILauncher | null,
     documentManager: IDocumentManager | null,
-    logConsoleTracker: ILogConsoleTracker | null,
-    chatTracker: IChatTracker | null
+    logConsoleTracker: ILogConsoleTracker | null
   ): IPluginPlayground => {
     if (completionManager) {
       completionManager.registerProvider(new CommandCompletionProvider(app));
@@ -3967,7 +4044,6 @@ const mainPlugin: JupyterFrontEndPlugin<IPluginPlayground> = {
         fileBrowserFactory,
         launcher,
         documentManager,
-        chatTracker,
         settings,
         requirejs,
         toolbarWidgetRegistry,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3416,7 +3416,9 @@ class PluginPlayground {
   private async _openOrRevealJupyterLiteAIChat(options?: {
     input?: string;
   }): Promise<void> {
-    if (!this.app.commands.hasCommand(JUPYTERLITE_AI_OPEN_OR_REVEAL_CHAT_COMMAND)) {
+    if (
+      !this.app.commands.hasCommand(JUPYTERLITE_AI_OPEN_OR_REVEAL_CHAT_COMMAND)
+    ) {
       throw new JupyterLiteAIError(
         'install-unavailable',
         JUPYTERLITE_AI_INSTALL_HINT
@@ -3531,7 +3533,10 @@ class PluginPlayground {
       }
       this._askAILogEntryActionDisposable = disposable;
     } catch (error) {
-      console.warn('Failed to update js-logs Ask AI action registration.', error);
+      console.warn(
+        'Failed to update js-logs Ask AI action registration.',
+        error
+      );
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -302,7 +302,6 @@ const LOAD_ON_SAVE_TOGGLE_TOOLBAR_ITEM = 'plugin-playground-load-on-save';
 const LOAD_ON_SAVE_CHECKBOX_LABEL = 'Run on save';
 const LOAD_ON_SAVE_SETTING = 'loadOnSave';
 const COMMAND_INSERT_DEFAULT_MODE_SETTING = 'commandInsertDefaultMode';
-const ASK_AI_LOG_ENTRY_ACTION_ENABLED_SETTING = 'askAILogEntryActionEnabled';
 const LOAD_ON_SAVE_ENABLED_DESCRIPTION =
   'Toggle auto-loading this file as an extension on save';
 const LOAD_ON_SAVE_DISABLED_DESCRIPTION =
@@ -899,6 +898,12 @@ class PluginPlayground {
         if (args.type === 'added' || args.type === 'removed') {
           tokenSidebar.update();
         }
+        if (
+          (args.type === 'added' || args.type === 'removed') &&
+          args.id === JUPYTERLITE_AI_OPEN_OR_REVEAL_CHAT_COMMAND
+        ) {
+          void this._updateAskAILogEntryActionRegistration();
+        }
       });
       // add to the launcher
       if (launcher && (settings.composite.showIconInLauncher as boolean)) {
@@ -937,7 +942,6 @@ class PluginPlayground {
         for (const refresh of this._loadOnSaveToggleRefreshers) {
           refresh();
         }
-        void this._updateAskAILogEntryActionRegistration();
       });
 
       this._setupLogsBadge();
@@ -3487,8 +3491,7 @@ class PluginPlayground {
     this._askAILogEntryActionDisposable = null;
 
     if (
-      this.settings.get(ASK_AI_LOG_ENTRY_ACTION_ENABLED_SETTING).composite !==
-      true
+      !this.app.commands.hasCommand(JUPYTERLITE_AI_OPEN_OR_REVEAL_CHAT_COMMAND)
     ) {
       return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,11 @@ import {
   ToolbarButton
 } from '@jupyterlab/apputils';
 
-import { ILogConsoleTracker } from 'jupyterlab-js-logs';
+import {
+  ILogConsoleTracker,
+  ILogEntryActionRegistry,
+  type ILogEntryActionMessage
+} from 'jupyterlab-js-logs';
 
 import { Signal } from '@lumino/signaling';
 
@@ -190,41 +194,6 @@ interface ILayoutHideSelection {
   hideStatusBar: boolean;
 }
 
-/**
- * Serialized log output payload passed by the js-logs action API.
- */
-type ISerializedLogOutput = Record<string, unknown>;
-
-/**
- * Log entry payload received by the js-logs entry action callback.
- */
-interface ILogEntryActionMessage {
-  source: string;
-  entryIndex: number;
-  level: string;
-  timestamp: Date | null;
-  text: string;
-  output: ISerializedLogOutput;
-}
-
-/**
- * Action definition registered with the js-logs entry action registry.
- */
-interface ILogEntryAction {
-  id: string;
-  label: string;
-  caption?: string;
-  isVisible?: (message: ILogEntryActionMessage) => boolean;
-  execute: (message: ILogEntryActionMessage) => void | Promise<void>;
-}
-
-/**
- * Registry interface exposed by js-logs for entry-level actions.
- */
-interface ILogEntryActionRegistry {
-  register(action: ILogEntryAction): { dispose: () => void };
-}
-
 const PLUGIN_TEMPLATE = `import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin,
@@ -344,8 +313,6 @@ const JUPYTERLITE_AI_OPEN_SETTINGS_COMMAND = '@jupyterlite/ai:open-settings';
 const JUPYTERLITE_AI_INSTALL_HINT =
   'JupyterLite AI is unavailable. Install the jupyterlite-ai extension and reload the application.';
 const JUPYTERLITE_AI_PROVIDER_SETUP_HINT = 'No AI provider configured.';
-const JS_LOGS_ENTRY_ACTION_REGISTRY_TOKEN_NAME =
-  'jupyterlab-js-logs:ILogEntryActionRegistry';
 const ASK_AI_LOG_ENTRY_ACTION_ID = 'plugin-playground:ask-ai-log-entry';
 const LOG_ENTRY_PROMPT_MAX_OUTPUT_LENGTH = 8000;
 type JupyterLiteAIErrorCode = 'install-unavailable' | 'provider-setup-required';
@@ -3543,18 +3510,9 @@ class PluginPlayground {
   private async _registerAskAILogEntryAction(): Promise<{
     dispose: () => void;
   } | null> {
-    try {
-      this._populateTokenMap();
-    } catch {
-      return null;
-    }
-    const token = this._tokenMap.get(
-      JS_LOGS_ENTRY_ACTION_REGISTRY_TOKEN_NAME
-    ) as unknown as Token<ILogEntryActionRegistry> | null;
-    if (!token) {
-      return null;
-    }
-    const actionRegistry = await this.app.resolveOptionalService(token);
+    const actionRegistry = await this.app.resolveOptionalService(
+      ILogEntryActionRegistry
+    );
     if (!actionRegistry) {
       return null;
     }
@@ -3565,11 +3523,10 @@ class PluginPlayground {
         label: 'Ask AI',
         caption: 'Open AI chat and include this log entry for debugging',
         isVisible: message => {
-          const hasText = message.text.trim().length > 0;
-          if (!hasText) {
+          if (message.level !== 'error' && message.level !== 'critical') {
             return false;
           }
-          return message.level === 'error' || message.level === 'critical';
+          return this._extractTextFromLogEntryMessage(message).length > 0;
         },
         execute: message => {
           void this._openAIChatForLogEntry(message);
@@ -3612,13 +3569,38 @@ class PluginPlayground {
   }
 
   private _buildLogEntryAIPrompt(message: ILogEntryActionMessage): string {
-    const rawText = message.text.trim();
+    const rawText = this._extractTextFromLogEntryMessage(message);
+    if (!rawText) {
+      return '';
+    }
     const trimmedText =
       rawText.length > LOG_ENTRY_PROMPT_MAX_OUTPUT_LENGTH
         ? `${rawText.slice(0, LOG_ENTRY_PROMPT_MAX_OUTPUT_LENGTH)}\n...`
         : rawText;
 
     return trimmedText;
+  }
+
+  private _extractTextFromLogEntryMessage(
+    message: ILogEntryActionMessage
+  ): string {
+    const rawData = message.output['data'];
+    if (
+      typeof rawData !== 'object' ||
+      rawData === null ||
+      Array.isArray(rawData)
+    ) {
+      return '';
+    }
+
+    const text = (rawData as Record<string, unknown>)['text/plain'];
+    if (typeof text === 'string') {
+      return text.trim();
+    }
+    if (Array.isArray(text) && text.every(item => typeof item === 'string')) {
+      return text.join('').trim();
+    }
+    return '';
   }
 
   private _buildCommandInsertAIPrompt(options: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -309,6 +309,8 @@ const LOAD_ON_SAVE_DISABLED_DESCRIPTION =
 const JUPYTERLITE_AI_OPEN_OR_REVEAL_CHAT_COMMAND =
   '@jupyterlite/ai:open-or-reveal-chat';
 const JUPYTERLITE_AI_OPEN_SETTINGS_COMMAND = '@jupyterlite/ai:open-settings';
+const JUPYTERLITE_AI_SETTINGS_MODEL_PLUGIN_ID =
+  '@jupyterlite/ai:settings-model';
 const JUPYTERLITE_AI_INSTALL_HINT =
   'JupyterLite AI is unavailable. Install the jupyterlite-ai extension and reload the application.';
 const JUPYTERLITE_AI_PROVIDER_SETUP_HINT = 'No AI provider configured.';
@@ -3485,6 +3487,77 @@ class PluginPlayground {
     }
   }
 
+  private async _loadJupyterLiteAISettings(): Promise<ISettingRegistry.ISettings | null> {
+    if (this._jupyterLiteAISettings) {
+      return this._jupyterLiteAISettings;
+    }
+    if (this._jupyterLiteAISettingsLoadPromise) {
+      return this._jupyterLiteAISettingsLoadPromise;
+    }
+
+    this._jupyterLiteAISettingsLoadPromise = this.settingRegistry
+      .load(JUPYTERLITE_AI_SETTINGS_MODEL_PLUGIN_ID)
+      .then(settings => {
+        this._jupyterLiteAISettings = settings;
+        settings.changed.connect(() => {
+          void this._updateAskAILogEntryActionRegistration();
+        });
+        return settings;
+      })
+      .catch(() => null)
+      .finally(() => {
+        this._jupyterLiteAISettingsLoadPromise = null;
+      });
+
+    return this._jupyterLiteAISettingsLoadPromise;
+  }
+
+  private async _hasConfiguredJupyterLiteAIProvider(): Promise<boolean> {
+    const aiSettings = await this._loadJupyterLiteAISettings();
+    if (!aiSettings) {
+      return false;
+    }
+
+    const providersValue = aiSettings.get('providers').composite;
+    if (!Array.isArray(providersValue) || providersValue.length === 0) {
+      return false;
+    }
+
+    const defaultProviderValue = aiSettings.get('defaultProvider').composite;
+    if (typeof defaultProviderValue !== 'string') {
+      return false;
+    }
+    const defaultProviderId = defaultProviderValue.trim();
+    if (!defaultProviderId) {
+      return false;
+    }
+
+    return providersValue.some(rawProvider => {
+      if (
+        !rawProvider ||
+        typeof rawProvider !== 'object' ||
+        Array.isArray(rawProvider)
+      ) {
+        return false;
+      }
+
+      const provider = rawProvider as Record<string, unknown>;
+      if (
+        typeof provider.id !== 'string' ||
+        typeof provider.provider !== 'string' ||
+        typeof provider.model !== 'string'
+      ) {
+        return false;
+      }
+
+      return (
+        provider.id.trim() === defaultProviderId &&
+        provider.provider.trim().length > 0 &&
+        provider.model.trim().length > 0
+      );
+    });
+  }
+
   private async _updateAskAILogEntryActionRegistration(): Promise<void> {
     const registrationEpoch = ++this._askAILogEntryActionRegistrationEpoch;
     this._askAILogEntryActionDisposable?.dispose();
@@ -3493,6 +3566,9 @@ class PluginPlayground {
     if (
       !this.app.commands.hasCommand(JUPYTERLITE_AI_OPEN_OR_REVEAL_CHAT_COMMAND)
     ) {
+      return;
+    }
+    if (!(await this._hasConfiguredJupyterLiteAIProvider())) {
       return;
     }
     try {
@@ -3576,12 +3652,10 @@ class PluginPlayground {
     if (!rawText) {
       return '';
     }
-    const trimmedText =
-      rawText.length > LOG_ENTRY_PROMPT_MAX_OUTPUT_LENGTH
-        ? `${rawText.slice(0, LOG_ENTRY_PROMPT_MAX_OUTPUT_LENGTH)}\n...`
-        : rawText;
-
-    return trimmedText;
+    if (rawText.length > LOG_ENTRY_PROMPT_MAX_OUTPUT_LENGTH) {
+      return `${rawText.slice(0, LOG_ENTRY_PROMPT_MAX_OUTPUT_LENGTH)}\n...`;
+    }
+    return rawText;
   }
 
   private _extractTextFromLogEntryMessage(
@@ -3970,6 +4044,9 @@ class PluginPlayground {
     string,
     ISettingRegistry.ISchema
   >();
+  private _jupyterLiteAISettings: ISettingRegistry.ISettings | null = null;
+  private _jupyterLiteAISettingsLoadPromise: Promise<ISettingRegistry.ISettings | null> | null =
+    null;
   private _askAILogEntryActionRegistrationEpoch = 0;
   private _askAILogEntryActionDisposable: { dispose: () => void } | null = null;
   private _commandInsertMode: CommandInsertMode = DEFAULT_COMMAND_INSERT_MODE;

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -58,8 +58,8 @@ const CSS_IMPORT_TEST_UPDATED_COLOR = 'rgb(34, 68, 102)';
 const CSS_IMPORT_TEST_BROKEN_MODULE_ERROR = 'css import rollback test failure';
 const COMMAND_COMPLETION_FILE = 'command-completion.ts';
 const INVOKE_FILE_COMPLETER_COMMAND = 'completer:invoke-file';
-const JUPYTERLITE_AI_OPEN_CHAT_COMMAND = '@jupyterlite/ai:open-chat';
-const JUPYTERLITE_AI_CHAT_PANEL_ID = '@jupyterlite/ai:chat-panel';
+const JUPYTERLITE_AI_OPEN_OR_REVEAL_CHAT_COMMAND =
+  '@jupyterlite/ai:open-or-reveal-chat';
 const PLAYGROUND_SIDEBAR_ID = 'jp-plugin-playground-sidebar';
 const TOKEN_SECTION_ID = 'jp-plugin-token-sidebar';
 const EXAMPLE_SECTION_ID = 'jp-plugin-example-sidebar';
@@ -391,13 +391,7 @@ async function ensureMockJupyterLiteAIChat(
   page: IJupyterLabPageFixture
 ): Promise<void> {
   await page.evaluate(
-    ({
-      commandId,
-      chatPanelId
-    }: {
-      commandId: string;
-      chatPanelId: string;
-    }) => {
+    ({ commandId }: { commandId: string }) => {
       const inputSelector =
         '.jp-chat-input-textfield[data-playground-test="ai-input"] textarea';
       const ensureInput = (): HTMLTextAreaElement => {
@@ -416,71 +410,16 @@ async function ensureMockJupyterLiteAIChat(
         return input;
       };
 
-      const inputModel = {
-        get value(): string {
-          return ensureInput().value;
-        },
-        set value(nextValue: string) {
-          const input = ensureInput();
-          input.value = nextValue;
+      const applyOpenArgs = (args?: any): void => {
+        const input = ensureInput();
+        if (typeof args?.input === 'string') {
+          input.value = args.input;
           input.dispatchEvent(new Event('input', { bubbles: true }));
           input.dispatchEvent(new Event('change', { bubbles: true }));
-        },
-        focus: () => {
-          ensureInput().focus();
         }
-      };
-
-      const app = window.jupyterapp as any;
-      const chatWidget = {
-        id: chatPanelId,
-        model: {
-          input: inputModel
+        if (args?.focus !== false) {
+          input.focus();
         }
-      };
-      app.__playgroundChatTracker = {
-        currentWidget: chatWidget,
-        find: (predicate: (widget: unknown) => boolean) =>
-          predicate(chatWidget) ? chatWidget : null
-      };
-      if (
-        !app.__playgroundOriginalResolveOptionalService &&
-        typeof app.resolveOptionalService === 'function'
-      ) {
-        app.__playgroundOriginalResolveOptionalService =
-          app.resolveOptionalService.bind(app);
-        app.resolveOptionalService = async (token: { name?: string }) => {
-          if (token?.name === '@jupyter/chat:IChatTracker') {
-            return app.__playgroundChatTracker;
-          }
-          return app.__playgroundOriginalResolveOptionalService(token);
-        };
-      }
-
-      const shell = window.jupyterapp.shell as any;
-      if (!shell.__playgroundOriginalWidgets) {
-        shell.__playgroundOriginalWidgets = shell.widgets.bind(shell);
-        shell.widgets = (area: string) => {
-          const originalWidgets = Array.from(
-            shell.__playgroundOriginalWidgets(area)
-          );
-          if (
-            (area === 'left' || area === 'right') &&
-            shell.__playgroundChatPanel
-          ) {
-            const chatPanel = shell.__playgroundChatPanel;
-            const widgetsWithoutChatPanel = originalWidgets.filter(
-              (widget: any) => widget?.id !== chatPanel.id
-            );
-            widgetsWithoutChatPanel.push(chatPanel);
-            return widgetsWithoutChatPanel[Symbol.iterator]();
-          }
-          return originalWidgets[Symbol.iterator]();
-        };
-      }
-      shell.__playgroundChatPanel = {
-        id: chatPanelId,
-        current: chatWidget
       };
 
       const commands = window.jupyterapp.commands;
@@ -490,8 +429,8 @@ async function ensureMockJupyterLiteAIChat(
           commands.execute.bind(commands);
         commands.execute = async (id: string, args?: any) => {
           if (id === commandId) {
-            ensureInput();
-            return undefined;
+            applyOpenArgs(args);
+            return true;
           }
           return commandRegistry.__playgroundOriginalExecute(id, args);
         };
@@ -500,9 +439,9 @@ async function ensureMockJupyterLiteAIChat(
         commands.addCommand(commandId, {
           label: 'JupyterLite AI test command',
           describedBy: { args: null },
-          execute: () => {
-            ensureInput();
-            return undefined;
+          execute: (args?: any) => {
+            applyOpenArgs(args);
+            return true;
           }
         });
       }
@@ -510,8 +449,7 @@ async function ensureMockJupyterLiteAIChat(
       ensureInput();
     },
     {
-      commandId: JUPYTERLITE_AI_OPEN_CHAT_COMMAND,
-      chatPanelId: JUPYTERLITE_AI_CHAT_PANEL_ID
+      commandId: JUPYTERLITE_AI_OPEN_OR_REVEAL_CHAT_COMMAND
     }
   );
 }

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -61,7 +61,6 @@ const INVOKE_FILE_COMPLETER_COMMAND = 'completer:invoke-file';
 const JUPYTERLITE_AI_OPEN_OR_REVEAL_CHAT_COMMAND =
   '@jupyterlite/ai:open-or-reveal-chat';
 const JS_LOGS_OPEN_COMMAND = 'js-logs:open';
-const ASK_AI_LOG_ENTRY_ACTION_ENABLED_SETTING = 'askAILogEntryActionEnabled';
 const PLAYGROUND_SIDEBAR_ID = 'jp-plugin-playground-sidebar';
 const TOKEN_SECTION_ID = 'jp-plugin-token-sidebar';
 const EXAMPLE_SECTION_ID = 'jp-plugin-example-sidebar';
@@ -4441,15 +4440,6 @@ const run = (application: JupyterFrontEnd) => {
 });
 
 test.describe('JS logs Ask AI action', () => {
-  test.use({
-    mockSettings: {
-      ...galata.DEFAULT_SETTINGS,
-      [PLAYGROUND_PLUGIN_ID]: {
-        [ASK_AI_LOG_ENTRY_ACTION_ENABLED_SETTING]: true
-      }
-    }
-  });
-
   test('adds Ask AI button in log rows and prefills AI chat input', async ({
     page
   }) => {

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -60,6 +60,8 @@ const COMMAND_COMPLETION_FILE = 'command-completion.ts';
 const INVOKE_FILE_COMPLETER_COMMAND = 'completer:invoke-file';
 const JUPYTERLITE_AI_OPEN_OR_REVEAL_CHAT_COMMAND =
   '@jupyterlite/ai:open-or-reveal-chat';
+const JS_LOGS_OPEN_COMMAND = 'js-logs:open';
+const ASK_AI_LOG_ENTRY_ACTION_ENABLED_SETTING = 'askAILogEntryActionEnabled';
 const PLAYGROUND_SIDEBAR_ID = 'jp-plugin-playground-sidebar';
 const TOKEN_SECTION_ID = 'jp-plugin-token-sidebar';
 const EXAMPLE_SECTION_ID = 'jp-plugin-example-sidebar';
@@ -4436,6 +4438,69 @@ const run = (application: JupyterFrontEnd) => {
     const source = current.content.model.sharedModel.getSource();
     return source === expected;
   }, expectedSourceAfterInsert);
+});
+
+test.describe('JS logs Ask AI action', () => {
+  test.use({
+    mockSettings: {
+      ...galata.DEFAULT_SETTINGS,
+      [PLAYGROUND_PLUGIN_ID]: {
+        [ASK_AI_LOG_ENTRY_ACTION_ENABLED_SETTING]: true
+      }
+    }
+  });
+
+  test('adds Ask AI button in log rows and prefills AI chat input', async ({
+    page
+  }) => {
+    const logMarker = `ask-ai-log-row-${Date.now()}`;
+    const chatInput = page.locator(
+      '.jp-chat-input-textfield[data-playground-test="ai-input"] textarea'
+    );
+
+    await page.goto();
+    await ensureMockJupyterLiteAIChat(page);
+
+    const hasJSLogsCommand = await page.evaluate((id: string) => {
+      return window.jupyterapp.commands.hasCommand(id);
+    }, JS_LOGS_OPEN_COMMAND);
+    test.skip(
+      !hasJSLogsCommand,
+      'jupyterlab-js-logs is required for JS log row actions.'
+    );
+
+    await page.evaluate((id: string) => {
+      const commands = window.jupyterapp.commands;
+      if (!commands.isToggled(id)) {
+        return commands.execute(id);
+      }
+      return undefined;
+    }, JS_LOGS_OPEN_COMMAND);
+
+    await page.evaluate((message: string) => {
+      console.error(message);
+    }, logMarker);
+
+    const logRow = page.locator('.jp-OutputArea-child').filter({
+      hasText: logMarker
+    });
+    await expect(logRow).toHaveCount(1);
+    const askAIButton = logRow
+      .first()
+      .locator('button.jp-JSLogs-entryActionButton:has-text("Ask AI")');
+    await expect(askAIButton).toBeVisible();
+
+    await askAIButton.click();
+    await expect(chatInput).toHaveValue(new RegExp(escapeRegExp(logMarker)));
+
+    await page.evaluate(() => {
+      document
+        .querySelector(
+          '.jp-chat-input-textfield[data-playground-test="ai-input"]'
+        )
+        ?.remove();
+    });
+  });
 });
 
 test('commands tab can prompt JupyterLite AI and remember last insertion mode', async ({

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -460,10 +460,6 @@ async function ensureMockJupyterLiteAIChat(
   );
 }
 
-test.afterEach(async ({ page }) => {
-  await page.unrouteAll({ behavior: 'ignoreErrors' });
-});
-
 test('registers plugin playground commands', async ({ page }) => {
   await page.goto();
 

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -458,6 +458,10 @@ async function ensureMockJupyterLiteAIChat(
   );
 }
 
+test.afterEach(async ({ page }) => {
+  await page.unrouteAll({ behavior: 'ignoreErrors' });
+});
+
 test('registers plugin playground commands', async ({ page }) => {
   await page.goto();
 

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -43,7 +43,8 @@ const FEDERATED_RUNTIME_PACKAGE = '@jupyterlab/plugin-playground';
 const FEDERATED_RUNTIME_CONSUMER_PLUGIN_ID = 'runtime-consumer-test:plugin';
 const FEDERATED_RUNTIME_CONSUMER_COMMAND = 'runtime-consumer-test:check';
 const FEDERATED_RUNTIME_CONSUMER_FILE = 'runtime-consumer-test.ts';
-const SHARED_RUNTIME_PACKAGE = '@jupyter/chat';
+const SHARED_RUNTIME_PACKAGE = 'jupyterlab-js-logs';
+const SHARED_RUNTIME_TOKEN_NAME = 'jupyterlab-js-logs:ILogEntryActionRegistry';
 const SHARED_RUNTIME_CONSUMER_PLUGIN_ID = 'shared-runtime-consumer-test:plugin';
 const SHARED_RUNTIME_CONSUMER_COMMAND = 'shared-runtime-consumer-test:check';
 const SHARED_RUNTIME_CONSUMER_FILE = 'shared-runtime-consumer-test.ts';
@@ -1353,7 +1354,7 @@ test('loads plugin importing shared module outside known module map', async ({
   const consumerPath = `${tmpPath}/${SHARED_RUNTIME_CONSUMER_FILE}`;
   expect(KNOWN_MODULE_NAMES).not.toContain(SHARED_RUNTIME_PACKAGE);
   const consumerSource = `import { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application';
-import { IChatCommandRegistry } from '${SHARED_RUNTIME_PACKAGE}';
+import { ILogEntryActionRegistry } from '${SHARED_RUNTIME_PACKAGE}';
 
 const plugin: JupyterFrontEndPlugin<void> = {
   id: '${SHARED_RUNTIME_CONSUMER_PLUGIN_ID}',
@@ -1361,7 +1362,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
   activate: (app: JupyterFrontEnd) => {
     app.commands.addCommand('${SHARED_RUNTIME_CONSUMER_COMMAND}', {
       label: 'Shared Runtime Consumer Check',
-      execute: () => IChatCommandRegistry.name === '@jupyter/chat:IChatCommandRegistry'
+      execute: () => ILogEntryActionRegistry.name === '${SHARED_RUNTIME_TOKEN_NAME}'
     });
   }
 };
@@ -1429,7 +1430,7 @@ test('fails deterministically when required shared version is incompatible', asy
     packageJsonPath
   );
   const consumerSource = `import { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application';
-import { IChatCommandRegistry } from '${SHARED_RUNTIME_PACKAGE}';
+import { ILogEntryActionRegistry } from '${SHARED_RUNTIME_PACKAGE}';
 
 const plugin: JupyterFrontEndPlugin<void> = {
   id: '${SHARED_RUNTIME_INCOMPATIBLE_PLUGIN_ID}',
@@ -1437,7 +1438,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
   activate: (app: JupyterFrontEnd) => {
     app.commands.addCommand('shared-runtime-incompatible-test:check', {
       label: 'Shared Runtime Incompatible Check',
-      execute: () => IChatCommandRegistry.name
+      execute: () => ILogEntryActionRegistry.name
     });
   }
 };

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -64,6 +64,8 @@ const JUPYTERLITE_AI_SETTINGS_MODEL_PLUGIN_ID =
   '@jupyterlite/ai:settings-model';
 const JS_LOGS_OPEN_COMMAND = 'js-logs:open';
 const TEST_JUPYTERLITE_AI_PROVIDER_ID = 'playground-test-provider';
+const ASK_AI_LOG_ENTRY_ACTION_CAPTION =
+  'Open AI chat and include this log entry for debugging';
 const PLAYGROUND_SIDEBAR_ID = 'jp-plugin-playground-sidebar';
 const TOKEN_SECTION_ID = 'jp-plugin-token-sidebar';
 const EXAMPLE_SECTION_ID = 'jp-plugin-example-sidebar';
@@ -4501,9 +4503,9 @@ test.describe('JS logs Ask AI action', () => {
     });
     await expect(warningRow).toHaveCount(1);
     await expect(
-      warningRow
-        .first()
-        .locator('button.jp-JSLogs-entryActionButton:has-text("Ask AI")')
+      warningRow.first().getByRole('button', {
+        name: ASK_AI_LOG_ENTRY_ACTION_CAPTION
+      })
     ).toHaveCount(0);
 
     await page.evaluate((message: string) => {
@@ -4514,9 +4516,9 @@ test.describe('JS logs Ask AI action', () => {
       hasText: logMarker
     });
     await expect(logRow).toHaveCount(1);
-    const askAIButton = logRow
-      .first()
-      .locator('button.jp-JSLogs-entryActionButton:has-text("Ask AI")');
+    const askAIButton = logRow.first().getByRole('button', {
+      name: ASK_AI_LOG_ENTRY_ACTION_CAPTION
+    });
     await expect(askAIButton).toBeVisible();
 
     await askAIButton.click();
@@ -4576,9 +4578,9 @@ test.describe('JS logs Ask AI action without provider setup', () => {
     });
     await expect(logRow).toHaveCount(1);
     await expect(
-      logRow
-        .first()
-        .locator('button.jp-JSLogs-entryActionButton:has-text("Ask AI")')
+      logRow.first().getByRole('button', {
+        name: ASK_AI_LOG_ENTRY_ACTION_CAPTION
+      })
     ).toHaveCount(0);
   });
 });

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -60,7 +60,10 @@ const COMMAND_COMPLETION_FILE = 'command-completion.ts';
 const INVOKE_FILE_COMPLETER_COMMAND = 'completer:invoke-file';
 const JUPYTERLITE_AI_OPEN_OR_REVEAL_CHAT_COMMAND =
   '@jupyterlite/ai:open-or-reveal-chat';
+const JUPYTERLITE_AI_SETTINGS_MODEL_PLUGIN_ID =
+  '@jupyterlite/ai:settings-model';
 const JS_LOGS_OPEN_COMMAND = 'js-logs:open';
+const TEST_JUPYTERLITE_AI_PROVIDER_ID = 'playground-test-provider';
 const PLAYGROUND_SIDEBAR_ID = 'jp-plugin-playground-sidebar';
 const TOKEN_SECTION_ID = 'jp-plugin-token-sidebar';
 const EXAMPLE_SECTION_ID = 'jp-plugin-example-sidebar';
@@ -4440,13 +4443,106 @@ const run = (application: JupyterFrontEnd) => {
 });
 
 test.describe('JS logs Ask AI action', () => {
+  test.use({
+    mockSettings: {
+      ...galata.DEFAULT_SETTINGS,
+      [JUPYTERLITE_AI_SETTINGS_MODEL_PLUGIN_ID]: {
+        providers: [
+          {
+            id: TEST_JUPYTERLITE_AI_PROVIDER_ID,
+            name: 'Playground Test Provider',
+            provider: 'openai',
+            model: 'gpt-4o-mini'
+          }
+        ],
+        defaultProvider: TEST_JUPYTERLITE_AI_PROVIDER_ID
+      }
+    }
+  });
+
   test('adds Ask AI button in log rows and prefills AI chat input', async ({
     page
   }) => {
     const logMarker = `ask-ai-log-row-${Date.now()}`;
+    const warningMarker = `ask-ai-log-row-warning-${Date.now()}`;
     const chatInput = page.locator(
       '.jp-chat-input-textfield[data-playground-test="ai-input"] textarea'
     );
+
+    await page.goto();
+    await ensureMockJupyterLiteAIChat(page);
+
+    const hasJSLogsCommand = await page.evaluate((id: string) => {
+      return window.jupyterapp.commands.hasCommand(id);
+    }, JS_LOGS_OPEN_COMMAND);
+    test.skip(
+      !hasJSLogsCommand,
+      'jupyterlab-js-logs is required for JS log row actions.'
+    );
+
+    await page.evaluate((id: string) => {
+      const commands = window.jupyterapp.commands;
+      if (!commands.isToggled(id)) {
+        return commands.execute(id);
+      }
+      return undefined;
+    }, JS_LOGS_OPEN_COMMAND);
+
+    await page.evaluate((message: string) => {
+      console.warn(message);
+    }, warningMarker);
+
+    const warningRow = page.locator('.jp-OutputArea-child').filter({
+      hasText: warningMarker
+    });
+    await expect(warningRow).toHaveCount(1);
+    await expect(
+      warningRow
+        .first()
+        .locator('button.jp-JSLogs-entryActionButton:has-text("Ask AI")')
+    ).toHaveCount(0);
+
+    await page.evaluate((message: string) => {
+      console.error(message);
+    }, logMarker);
+
+    const logRow = page.locator('.jp-OutputArea-child').filter({
+      hasText: logMarker
+    });
+    await expect(logRow).toHaveCount(1);
+    const askAIButton = logRow
+      .first()
+      .locator('button.jp-JSLogs-entryActionButton:has-text("Ask AI")');
+    await expect(askAIButton).toBeVisible();
+
+    await askAIButton.click();
+    await expect(chatInput).toHaveValue(new RegExp(escapeRegExp(logMarker)));
+
+    await page.evaluate(() => {
+      document
+        .querySelector(
+          '.jp-chat-input-textfield[data-playground-test="ai-input"]'
+        )
+        ?.remove();
+    });
+  });
+});
+
+test.describe('JS logs Ask AI action without provider setup', () => {
+  test.use({
+    mockSettings: {
+      ...galata.DEFAULT_SETTINGS,
+      [JUPYTERLITE_AI_SETTINGS_MODEL_PLUGIN_ID]: {
+        providers: [],
+        defaultProvider: ''
+      }
+    }
+  });
+
+  test('does not add Ask AI button when no AI provider is configured', async ({
+    page
+  }) => {
+    const logMarker = `ask-ai-log-row-no-provider-${Date.now()}`;
 
     await page.goto();
     await ensureMockJupyterLiteAIChat(page);
@@ -4475,21 +4571,11 @@ test.describe('JS logs Ask AI action', () => {
       hasText: logMarker
     });
     await expect(logRow).toHaveCount(1);
-    const askAIButton = logRow
-      .first()
-      .locator('button.jp-JSLogs-entryActionButton:has-text("Ask AI")');
-    await expect(askAIButton).toBeVisible();
-
-    await askAIButton.click();
-    await expect(chatInput).toHaveValue(new RegExp(escapeRegExp(logMarker)));
-
-    await page.evaluate(() => {
-      document
-        .querySelector(
-          '.jp-chat-input-textfield[data-playground-test="ai-input"]'
-        )
-        ?.remove();
-    });
+    await expect(
+      logRow
+        .first()
+        .locator('button.jp-JSLogs-entryActionButton:has-text("Ask AI")')
+    ).toHaveCount(0);
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1868,7 +1868,7 @@ __metadata:
     "@typescript-eslint/parser": ^8.56.1
     eslint: ^9.39.3
     eslint-config-prettier: ^10.1.8
-    jupyterlab-js-logs: ^1.2.0
+    jupyterlab-js-logs: ^1.3.0
     npm-run-all: ^4.1.5
     prettier: ^2.8.0
     raw-loader: ^4.0.2
@@ -6776,9 +6776,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jupyterlab-js-logs@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "jupyterlab-js-logs@npm:1.2.0"
+"jupyterlab-js-logs@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "jupyterlab-js-logs@npm:1.3.0"
   dependencies:
     "@jupyterlab/application": ^4.2.5
     "@jupyterlab/apputils": ^4.3.5
@@ -6791,7 +6791,7 @@ __metadata:
     "@jupyterlab/ui-components": ^4.2.5
     "@lumino/coreutils": ^2.2.0
     "@lumino/widgets": ^2.5.0
-  checksum: f72d15d525b28f27fb43391d65134dc48163012553926971314b0131a00cbd89c871583331bf299253906e1e5f85b0e7bec032d5d087248d77e5dde78d703afc
+  checksum: c046f3d3d0364c171a4d46ef9384ea1488885690c25d2dae885ab2b6c7cc87d75ccb506ac8784b0c4f4a108722250d42ce2d5ea41d7791d4f024165f93a1be65
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1833,7 +1833,7 @@ __metadata:
     "@typescript-eslint/parser": ^8.56.1
     eslint: ^9.39.3
     eslint-config-prettier: ^10.1.8
-    jupyterlab-js-logs: ^1.3.0
+    jupyterlab-js-logs: ^1.3.1
     npm-run-all: ^4.1.5
     prettier: ^2.8.0
     raw-loader: ^4.0.2
@@ -6743,9 +6743,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jupyterlab-js-logs@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "jupyterlab-js-logs@npm:1.3.0"
+"jupyterlab-js-logs@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "jupyterlab-js-logs@npm:1.3.1"
   dependencies:
     "@jupyterlab/application": ^4.2.5
     "@jupyterlab/apputils": ^4.3.5
@@ -6758,7 +6758,7 @@ __metadata:
     "@jupyterlab/ui-components": ^4.2.5
     "@lumino/coreutils": ^2.2.0
     "@lumino/widgets": ^2.5.0
-  checksum: c046f3d3d0364c171a4d46ef9384ea1488885690c25d2dae885ab2b6c7cc87d75ccb506ac8784b0c4f4a108722250d42ce2d5ea41d7791d4f024165f93a1be65
+  checksum: b1cf33f9e16c3e7a48858d9e8155041eacd2eaafd32c6629dde207989d1772cb2c879f87916d2ac6c61eff7626ee0d52cbbd5c0c3a7e3e0c50d9f6f430d008d4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #194 

This PR adds an optional “Ask AI” button to JS Logs error/critical entries and routes it to JupyterLite AI using the new `open-or-reveal-chat` command with prompt prefill. The feature is gated behind a new user setting (`askAILogEntryActionEnabled`) that defaults to false, so no button appears unless explicitly enabled.