### PR TITLE
Include notebook files in Share Package selection

### DIFF
--- a/src/contents.ts
+++ b/src/contents.ts
@@ -62,7 +62,7 @@ export namespace ContentUtils {
   };
 
   export type IFileModel = Contents.IModel & {
-    type: 'file';
+    type: 'file' | 'notebook';
     content: unknown;
     format?: string | null;
   };
@@ -194,23 +194,27 @@ export namespace ContentUtils {
       const model = await getContentsModel(serviceManager, candidatePath, {
         content: true
       });
-      if (!model || model.type !== 'file') {
+      if (!model || (model.type !== 'file' && model.type !== 'notebook')) {
         continue;
       }
       if (model.content !== null) {
         return model as IFileModel;
       }
 
-      const textModel = await getContentsModel(serviceManager, candidatePath, {
-        content: true,
-        format: 'text'
-      });
+      const fallbackModel = await getContentsModel(
+        serviceManager,
+        candidatePath,
+        {
+          content: true,
+          format: model.type === 'notebook' ? 'json' : 'text'
+        }
+      );
       if (
-        textModel &&
-        textModel.type === 'file' &&
-        textModel.content !== null
+        fallbackModel &&
+        (fallbackModel.type === 'file' || fallbackModel.type === 'notebook') &&
+        fallbackModel.content !== null
       ) {
-        return textModel as IFileModel;
+        return fallbackModel as IFileModel;
       }
     }
     return null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1713,7 +1713,11 @@ class PluginPlayground {
     const filePaths: string[] = [];
 
     for (const item of directory.content) {
-      if (item.type !== 'directory' && item.type !== 'file') {
+      if (
+        item.type !== 'directory' &&
+        item.type !== 'file' &&
+        item.type !== 'notebook'
+      ) {
         continue;
       }
       if (

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -3363,6 +3363,77 @@ test('shares selected file or folder when using browser selection', async ({
   expect(folderShareResult.link).toContain('plugin=');
 });
 
+test('shows notebook files in folder share selection', async ({
+  page,
+  tmpPath
+}) => {
+  const projectRoot = `${tmpPath}/share-browser-selection-notebook-test`;
+  const folderPath = `${projectRoot}/src`;
+  const sourcePath = `${folderPath}/index.ts`;
+  const notebookPath = `${folderPath}/repro.ipynb`;
+
+  await page.contents.uploadContent(TEST_PLUGIN_SOURCE, 'text', sourcePath);
+  await page.evaluate(async (path: string) => {
+    await window.jupyterapp.serviceManager.contents.save(path, {
+      type: 'notebook',
+      format: 'json',
+      content: {
+        cells: [
+          {
+            cell_type: 'code',
+            execution_count: null,
+            metadata: {},
+            outputs: [],
+            source: ['print("repro notebook")\n']
+          }
+        ],
+        metadata: {},
+        nbformat: 4,
+        nbformat_minor: 5
+      }
+    });
+  }, notebookPath);
+  await page.goto();
+
+  await page.waitForCondition(() =>
+    page.evaluate((id: string) => {
+      return window.jupyterapp.commands.hasCommand(id);
+    }, SHARE_COMMAND)
+  );
+
+  await page.filebrowser.openDirectory(projectRoot);
+  const browserSection = page.getByRole('region', {
+    name: 'File Browser Section'
+  });
+  const folderItem = browserSection.getByRole('listitem', {
+    name: /^Name: src/
+  });
+  await folderItem.click();
+
+  const sharePromise = page.evaluate((id: string) => {
+    return window.jupyterapp.commands.execute(id, {
+      useBrowserSelection: true
+    });
+  }, SHARE_COMMAND);
+
+  const notebookCheckbox = page
+    .locator('label', { hasText: /^repro\.ipynb \(/ })
+    .locator('input[type="checkbox"]');
+  await expect(notebookCheckbox).toBeVisible();
+  await expect(notebookCheckbox).toBeChecked();
+
+  const shareSelectedFilesButton = page.getByRole('button', {
+    name: 'Share Selected Files',
+    exact: true
+  });
+  await shareSelectedFilesButton.click();
+
+  const shareResult = await sharePromise;
+  expect(shareResult.ok).toBe(true);
+  expect(shareResult.sourcePath).toBe(folderPath);
+  expect(shareResult.link).toContain('plugin=');
+});
+
 test('does not fall back to browser selection when context target is required', async ({
   page,
   tmpPath

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -3373,6 +3373,12 @@ test('shows notebook files in folder share selection', async ({
   const notebookPath = `${folderPath}/repro.ipynb`;
 
   await page.contents.uploadContent(TEST_PLUGIN_SOURCE, 'text', sourcePath);
+  await page.goto();
+  await page.waitForCondition(() =>
+    page.evaluate((id: string) => {
+      return window.jupyterapp.commands.hasCommand(id);
+    }, SHARE_COMMAND)
+  );
   await page.evaluate(async (path: string) => {
     await window.jupyterapp.serviceManager.contents.save(path, {
       type: 'notebook',
@@ -3393,12 +3399,14 @@ test('shows notebook files in folder share selection', async ({
       }
     });
   }, notebookPath);
-  await page.goto();
 
   await page.waitForCondition(() =>
-    page.evaluate((id: string) => {
-      return window.jupyterapp.commands.hasCommand(id);
-    }, SHARE_COMMAND)
+    page.evaluate(async (path: string) => {
+      const model = await window.jupyterapp.serviceManager.contents.get(path, {
+        content: false
+      });
+      return model?.type === 'notebook';
+    }, notebookPath)
   );
 
   await page.filebrowser.openDirectory(projectRoot);


### PR DESCRIPTION
fixes #240 by making folder sharing treat notebook entries (`type: "notebook"`) as shareable files, so `.ipynb` files show up in the Share Package file-selection dialog and are included in generated share links