### PR TITLE
Improve Plugin Playground authoring guidance for multi-file plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ There are a few differences in how to write plugins in Plugin Playground compare
 - To load code from an external package, RequireJS is used (hidden behind ES module-compatible import syntax), so import statements may need explicit version or file paths.
   - In addition to JupyterLab and Lumino packages, only AMD modules can be imported; ES modules and modules compiled for Webpack/Node are not supported directly and can fail with `Uncaught SyntaxError: Unexpected token 'export'`.
 - The playground can import relative files (`.ts`, `.tsx`, `.js`, and `.css`), load SVG as strings, and load settings schema from `package.json` (`jupyterlab.schemaDir`) with `plugin.json` fallback for single-plugin prototyping.
+- For multi-file prototypes, create a package root with `package.json` before adding files under `src/`, `schema/`, or `style/`. This lets `Share Package` and extension export find the whole plugin folder reliably.
+- Playground prototypes cannot replace existing JupyterLab commands by reusing their command IDs. Register your own command ID and add it to the relevant menu, toolbar, launcher, palette, or cell toolbar instead.
 
 ### Migrating from version 0.3.0
 

--- a/_agents/skills/plugin-authoring/SKILL.md
+++ b/_agents/skills/plugin-authoring/SKILL.md
@@ -37,7 +37,22 @@ Produce working plugin code that can be loaded with `plugin-playground:load-as-e
 - If the user does not already have a plugin file open or specified, run `plugin-playground:create-new-plugin` with a meaningful `path` argument (for example `app.commands.execute('plugin-playground:create-new-plugin', { path: 'status-indicator.ts' })`) instead of relying on untitled defaults.
 - Start from the generated TypeScript scaffold and adapt it.
 - Plugin Playground supports schema-backed settings during prototyping (`package.json` with `jupyterlab.schemaDir`, with `plugin.json` fallback for single-plugin cases).
+- For any plugin with multiple files, settings schema, CSS, SVG, or other local assets, create a package root up front (for example `my-extension/src/index.ts`) and include a minimal `package.json` in `my-extension/` so `Share Package` and extension export operate on the full folder.
+- When creating nested files through AI file commands, create the parent directories first and verify the files appear in the file browser before continuing.
 - Focus on TypeScript/TSX plugin code. Do not scaffold Python projects (`pyproject.toml`, Python package layout) unless explicitly requested.
+
+Minimal package metadata for Playground prototypes:
+
+```json
+{
+  "name": "my-extension",
+  "version": "0.1.0",
+  "jupyterlab": {
+    "extension": true,
+    "schemaDir": "schema"
+  }
+}
+```
 
 2. Discover available extension points
 
@@ -57,7 +72,8 @@ Produce working plugin code that can be loaded with `plugin-playground:load-as-e
 
 - Start from a minimal plugin shape (`id`, `autoStart`, `activate`).
 - Add `requires` tokens only after confirming availability from step 2.
-- Add commands with stable IDs (`<namespace>:<action>`).
+- Add commands with stable, unique IDs (`<namespace>:<action>`).
+- Do not overwrite or reuse built-in JupyterLab command IDs. Plugin Playground skips duplicate command registrations; register a separate command and add it to the relevant palette, menu, toolbar, launcher, or cell toolbar instead.
 - Use one or more `.ts`/`.tsx` files as needed as complexity grows.
 
 5. Load and iterate

--- a/src/index.ts
+++ b/src/index.ts
@@ -651,6 +651,15 @@ class PluginPlayground {
           }
 
           if (targetPath !== model.path) {
+            const targetDirectory = ContentUtils.normalizeContentsPath(
+              PathExt.dirname(targetPath)
+            ).replace(/^\.$/, '');
+            if (targetDirectory) {
+              await ContentUtils.ensureContentsDirectory(
+                app.serviceManager,
+                targetDirectory
+              );
+            }
             openPath = (
               await app.serviceManager.contents.rename(model.path, targetPath)
             ).path;


### PR DESCRIPTION
Part of: #189 

Updates the bundled plugin authoring `skill` and `README` to clarify that Plugin Playground supports schema-backed settings, multi-file plugin roots with `package.json`, and package sharing/export workflows. Also guides agents to create parent directories before nested files and avoid reusing built-in JupyterLab command IDs, since replacement commands are skipped rather than overriding existing registrations.