### PR TITLE
Add currently loaded playground plugins panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Plugin Playground is built to keep the full plugin prototyping workflow inside J
 ![Export format dropdown in editor toolbar](docs/images/readme/editor-toolbar-export-dropdown.png)
 ![Share target dropdown in editor toolbar](docs/images/readme/editor-toolbar-share-dropdown.png)
 
-The right sidebar includes a single Plugin Playground panel with two collapsible sections. In **Extension Points**, the `Tokens` tab helps you discover available token strings and insert import/dependency updates, the `Commands` tab lets you search command IDs, inspect argument docs, and insert execution snippets (either directly or through AI-assisted prompt mode), and the `Packages` tab surfaces package docs plus npm and repository links for known modules.
+The right sidebar includes a single Plugin Playground panel with three collapsible sections. In **Extension Points**, the `Tokens` tab helps you discover available token strings and insert import/dependency updates, the `Commands` tab lets you search command IDs, inspect argument docs, and insert execution snippets (either directly or through AI-assisted prompt mode), and the `Packages` tab surfaces package docs plus npm and repository links for known modules.
 
 ![Extension Points token discovery and insertion actions](docs/images/readme/extension-points-tokens.png)
 ![Extension Points command discovery and insertion actions](docs/images/readme/extension-points-commands.png)
@@ -41,6 +41,8 @@ The right sidebar includes a single Plugin Playground panel with two collapsible
 The **Extension Examples** section lists discovered examples from `extension-examples/` and lets you open source entrypoints and README files directly. This keeps reference implementations close while you prototype.
 
 ![Extension Examples section with code and README actions](docs/images/readme/extension-examples.png)
+
+The **Currently Loaded Plugins** section lists plugins loaded by Plugin Playground in the current session, shows each plugin's source path, and lets you deactivate a selected plugin without clearing the rest of the session.
 
 Command completion is also included for `app.commands.execute(...)` / `commands.execute(...)` in JavaScript and TypeScript editors, and Notebook v7 integrates `Start from File`, `Build with AI`, and `Take the Tour` into New-file flows so you can create starter plugin files from the tree interface.
 
@@ -61,7 +63,7 @@ jlpm docs:screenshots
 3. Paste plugin code into the active editor.
 4. Run `Load Current File As Extension` from the editor toolbar or Command Palette.
 5. Use the `Run on save` icon button for fast iteration on one file.
-6. Use the sidebar to discover tokens, commands, packages, and extension examples.
+6. Use the sidebar to discover tokens, commands, packages, extension examples, and currently loaded playground plugins.
 
 For extension examples availability:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,7 @@ import {
 } from './token-sidebar';
 
 import { ExampleSidebar, filterExampleRecords } from './example-sidebar';
+import { LoadedPluginsSidebar } from './loaded-plugins-sidebar';
 import { createFloatingUrlLoadHint } from './components/url-load-hint';
 
 import { loadOnSaveToggleIcon, runTileIcon, tokenSidebarIcon } from './icons';
@@ -873,12 +874,23 @@ class PluginPlayground {
       exampleSidebar.title.caption =
         'Browse plugin examples from jupyterlab/extension-examples';
 
+      const loadedPluginsSidebar = new LoadedPluginsSidebar({
+        getLoadedPlugins: this._getLoadedPluginRecords.bind(this),
+        onDeactivate: this._deactivateLoadedPlugin.bind(this)
+      });
+      this._loadedPluginsSidebar = loadedPluginsSidebar;
+      loadedPluginsSidebar.id = 'jp-plugin-loaded-sidebar';
+      loadedPluginsSidebar.title.label = 'Currently Loaded Plugins';
+      loadedPluginsSidebar.title.caption =
+        'Playground-loaded plugins active in this session';
+
       const playgroundSidebar = new SidePanel();
       playgroundSidebar.id = 'jp-plugin-playground-sidebar';
       playgroundSidebar.title.caption = 'Plugin Playground helper panels';
       playgroundSidebar.title.icon = tokenSidebarIcon;
       playgroundSidebar.addWidget(tokenSidebar);
       playgroundSidebar.addWidget(exampleSidebar);
+      playgroundSidebar.addWidget(loadedPluginsSidebar);
       this.app.shell.add(playgroundSidebar, 'right', { rank: 650 });
       this._playgroundSidebar = playgroundSidebar;
       this._expandPlaygroundSidebarSections();
@@ -2107,6 +2119,7 @@ class PluginPlayground {
 
       for (const plugin of plugins) {
         await this._deactivateAndDeregisterPlugin(plugin.id);
+        this._loadedPluginRecords.delete(plugin.id);
         this.app.registerPlugin(plugin);
         newlyRegisteredPluginIds.push(plugin.id);
       }
@@ -2151,6 +2164,7 @@ class PluginPlayground {
       }
       const message = error instanceof Error ? error.message : String(error);
       showErrorMessage('Plugin loading failed', message);
+      this._refreshLoadedPlugins();
       return {
         status: 'loading-failed',
         ok: false,
@@ -2212,6 +2226,7 @@ class PluginPlayground {
       skippedAutoStartPluginIds.length > 0
         ? skippedAutoStartPluginIds
         : undefined;
+    this._recordLoadedPlugins(pluginIds, path);
     return {
       status: 'loaded',
       ok: true,
@@ -2664,6 +2679,42 @@ class PluginPlayground {
     this._tokenSidebar?.update();
   }
 
+  private _getLoadedPluginRecords(): ReadonlyArray<LoadedPluginsSidebar.ILoadedPluginRecord> {
+    return Array.from(this._loadedPluginRecords.values())
+      .filter(plugin => this.app.hasPlugin(plugin.id))
+      .sort((left, right) => left.id.localeCompare(right.id));
+  }
+
+  private _recordLoadedPlugins(
+    pluginIds: ReadonlyArray<string>,
+    path: string | null
+  ): void {
+    const sourcePath = path ? ContentUtils.normalizeContentsPath(path) : null;
+    for (const pluginId of pluginIds) {
+      this._loadedPluginRecords.set(pluginId, {
+        id: pluginId,
+        sourcePath
+      });
+    }
+    this._refreshLoadedPlugins();
+  }
+
+  private _refreshLoadedPlugins(): void {
+    this._loadedPluginsSidebar?.update();
+  }
+
+  private async _deactivateLoadedPlugin(pluginId: string): Promise<void> {
+    await this._deactivateAndDeregisterPlugin(pluginId);
+    this._removePluginLocalStyles(pluginId);
+    this._removeDynamicSettingPlugin(pluginId);
+    this._loadedPluginRecords.delete(pluginId);
+    this._refreshExtensionPoints();
+    this._refreshLoadedPlugins();
+    Notification.success(`Deactivated "${pluginId}".`, {
+      autoClose: 3500
+    });
+  }
+
   private _syncPluginLocalStyles(
     pluginId: string,
     nextPaths: ReadonlySet<string>
@@ -2703,6 +2754,33 @@ class PluginPlayground {
     return false;
   }
 
+  private _removePluginLocalStyles(pluginId: string): void {
+    const previousPaths = this._pluginLocalStylePaths.get(pluginId);
+    if (!previousPaths) {
+      return;
+    }
+    for (const previousPath of previousPaths) {
+      if (this._isStylePathUsedByOtherPlugins(previousPath, pluginId)) {
+        continue;
+      }
+      ImportResolver.removeLocalStyles([previousPath]);
+    }
+    this._pluginLocalStylePaths.delete(pluginId);
+  }
+
+  private _removeDynamicSettingPlugin(pluginId: string): void {
+    if (!this._dynamicSettingPlugins.delete(pluginId)) {
+      return;
+    }
+    delete this.settingRegistry.plugins[pluginId];
+    this._removeDynamicSettingStorageValue(
+      `${DYNAMIC_SETTINGS_STORAGE_KEY_PREFIX}${pluginId}`
+    );
+    (
+      this.settingRegistry.pluginChanged as Signal<ISettingRegistry, string>
+    ).emit(pluginId);
+  }
+
   public async registerKnownModule(known: IKnownModule): Promise<void> {
     registerKnownModule(known);
     this._tokenSidebar?.update();
@@ -2728,6 +2806,7 @@ class PluginPlayground {
     if (content instanceof AccordionPanel) {
       content.expand(0);
       content.expand(1);
+      content.expand(2);
     }
   }
 
@@ -4053,6 +4132,10 @@ class PluginPlayground {
     MainAreaWidget<IFrame>
   >();
   private readonly _pluginLocalStylePaths = new Map<string, Set<string>>();
+  private readonly _loadedPluginRecords = new Map<
+    string,
+    LoadedPluginsSidebar.ILoadedPluginRecord
+  >();
   private readonly _dynamicSettingPlugins = new Map<
     string,
     ISettingRegistry.ISchema
@@ -4065,6 +4148,7 @@ class PluginPlayground {
   private _commandInsertMode: CommandInsertMode = DEFAULT_COMMAND_INSERT_MODE;
   private _playgroundSidebar: SidePanel | null = null;
   private _tokenSidebar: TokenSidebar | null = null;
+  private _loadedPluginsSidebar: LoadedPluginsSidebar | null = null;
   private _documentationWidgetId = 0;
 }
 

--- a/src/loaded-plugins-sidebar.tsx
+++ b/src/loaded-plugins-sidebar.tsx
@@ -1,0 +1,102 @@
+import { Dialog, ReactWidget, showDialog } from '@jupyterlab/apputils';
+
+import { stopIcon } from '@jupyterlab/ui-components';
+
+import * as React from 'react';
+
+export namespace LoadedPluginsSidebar {
+  export interface ILoadedPluginRecord {
+    id: string;
+    sourcePath: string | null;
+  }
+
+  export interface IOptions {
+    getLoadedPlugins: () => ReadonlyArray<ILoadedPluginRecord>;
+    onDeactivate: (pluginId: string) => Promise<void>;
+  }
+}
+
+export class LoadedPluginsSidebar extends ReactWidget {
+  constructor(options: LoadedPluginsSidebar.IOptions) {
+    super();
+    this._getLoadedPlugins = options.getLoadedPlugins;
+    this._onDeactivate = options.onDeactivate;
+    this.addClass('jp-PluginPlayground-sidebar');
+  }
+
+  render(): JSX.Element {
+    const loadedPlugins = this._getLoadedPlugins();
+
+    return (
+      <div className="jp-PluginPlayground-sidebarInner">
+        {loadedPlugins.length === 0 ? (
+          <p className="jp-PluginPlayground-count">
+            No playground plugins are currently loaded.
+          </p>
+        ) : (
+          <ul className="jp-PluginPlayground-list">
+            {loadedPlugins.map(plugin => {
+              const isDeactivating = this._deactivatingPluginIds.has(plugin.id);
+              return (
+                <li key={plugin.id} className="jp-PluginPlayground-listItem">
+                  <div className="jp-PluginPlayground-row">
+                    <code className="jp-PluginPlayground-entryLabel jp-PluginPlayground-tokenString">
+                      {plugin.id}
+                    </code>
+                    <div className="jp-PluginPlayground-tokenActions">
+                      <button
+                        className="jp-Button jp-mod-styled jp-mod-minimal jp-PluginPlayground-actionButton jp-PluginPlayground-deactivateButton"
+                        type="button"
+                        disabled={isDeactivating}
+                        onClick={() => {
+                          void this._deactivate(plugin.id);
+                        }}
+                        aria-label={`Deactivate ${plugin.id}`}
+                        title="Deactivate plugin"
+                      >
+                        {React.createElement(stopIcon.react, {
+                          tag: 'span',
+                          elementSize: 'normal',
+                          className: 'jp-PluginPlayground-actionIcon'
+                        })}
+                        <span className="jp-PluginPlayground-actionLabel">
+                          Deactivate
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <p className="jp-PluginPlayground-description">
+                    {plugin.sourcePath ?? 'Unknown source'}
+                  </p>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    );
+  }
+
+  private async _deactivate(pluginId: string): Promise<void> {
+    this._deactivatingPluginIds.add(pluginId);
+    this.update();
+    try {
+      await this._onDeactivate(pluginId);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Unknown deactivation error';
+      await showDialog({
+        title: 'Plugin deactivation failed',
+        body: `Could not deactivate "${pluginId}". ${message}`,
+        buttons: [Dialog.okButton()]
+      });
+    } finally {
+      this._deactivatingPluginIds.delete(pluginId);
+      this.update();
+    }
+  }
+
+  private readonly _getLoadedPlugins: () => ReadonlyArray<LoadedPluginsSidebar.ILoadedPluginRecord>;
+  private readonly _onDeactivate: (pluginId: string) => Promise<void>;
+  private readonly _deactivatingPluginIds = new Set<string>();
+}

--- a/style/base.css
+++ b/style/base.css
@@ -218,6 +218,10 @@
   background: var(--jp-layout-color3);
 }
 
+.jp-PluginPlayground-deactivateButton {
+  color: var(--jp-error-color1);
+}
+
 .jp-PluginPlayground-splitAction
   .jp-PluginPlayground-actionButton:not(:disabled):hover {
   background: var(--jp-layout-color2);

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -70,6 +70,7 @@ const ASK_AI_LOG_ENTRY_ACTION_CAPTION =
 const PLAYGROUND_SIDEBAR_ID = 'jp-plugin-playground-sidebar';
 const TOKEN_SECTION_ID = 'jp-plugin-token-sidebar';
 const EXAMPLE_SECTION_ID = 'jp-plugin-example-sidebar';
+const LOADED_PLUGINS_SECTION_ID = 'jp-plugin-loaded-sidebar';
 const LOAD_ON_SAVE_CHECKBOX_LABEL = 'Run on save';
 const FOLDER_SHARE_DISABLE_DIALOG_CHECKBOX_LABEL =
   'Do not ask me again if all files can be included';
@@ -1284,6 +1285,91 @@ test('loads current editor file as a plugin extension', async ({
       return window.jupyterapp.commands.isToggled(id);
     }, TEST_TOGGLE_COMMAND)
   ).resolves.toBe(true);
+});
+
+test('lists loaded plugins and deactivates a selected plugin', async ({
+  page,
+  tmpPath
+}) => {
+  const pluginPath = `${tmpPath}/loaded-plugin-sidebar-test.ts`;
+  const pluginId = 'loaded-plugin-sidebar-test:plugin';
+  const commandId = 'loaded-plugin-sidebar-test:command';
+  const source = `
+const plugin = {
+  id: '${pluginId}',
+  autoStart: true,
+  activate: app => {
+    app.commands.addCommand('${commandId}', {
+      label: 'Loaded Plugin Sidebar Test Command',
+      execute: () => true
+    });
+  },
+  deactivate: () => {
+    window.__loadedPluginSidebarDeactivateCount =
+      (window.__loadedPluginSidebarDeactivateCount ?? 0) + 1;
+  }
+};
+
+export default plugin;
+`;
+
+  await page.contents.uploadContent(source, 'text', pluginPath);
+  await page.goto();
+  await page.filebrowser.open(pluginPath);
+  expect(await page.activity.activateTab('loaded-plugin-sidebar-test.ts')).toBe(
+    true
+  );
+
+  await page.waitForCondition(() =>
+    page.evaluate((id: string) => {
+      return window.jupyterapp.commands.hasCommand(id);
+    }, LOAD_COMMAND)
+  );
+  const loadResult = await page.evaluate((id: string) => {
+    return window.jupyterapp.commands.execute(id);
+  }, LOAD_COMMAND);
+  expect(loadResult.ok).toBe(true);
+  expect(loadResult.status).toBe('loaded');
+  expect(loadResult.pluginIds).toContain(pluginId);
+
+  const section = await openSidebarPanel(page, LOADED_PLUGINS_SECTION_ID);
+  await expect(section.locator('.jp-PluginPlayground-entryLabel')).toHaveText([
+    pluginId
+  ]);
+  await expect(section.locator('.jp-PluginPlayground-description')).toHaveText(
+    pluginPath
+  );
+
+  const deactivateButton = section.getByRole('button', {
+    name: `Deactivate ${pluginId}`
+  });
+  await expect(deactivateButton).toBeVisible();
+  await deactivateButton.click();
+
+  await page.waitForCondition(() =>
+    page.evaluate(
+      ({ loadedPluginId, loadedCommandId }) => {
+        const testWindow = window as Window & {
+          __loadedPluginSidebarDeactivateCount?: number;
+        };
+        return (
+          !window.jupyterapp.hasPlugin(loadedPluginId) &&
+          !window.jupyterapp.commands.hasCommand(loadedCommandId) &&
+          testWindow.__loadedPluginSidebarDeactivateCount === 1
+        );
+      },
+      {
+        loadedPluginId: pluginId,
+        loadedCommandId: commandId
+      }
+    )
+  );
+  await expect(section.locator('.jp-PluginPlayground-listItem')).toHaveCount(0);
+  await expect(
+    section.getByText('No playground plugins are currently loaded.', {
+      exact: true
+    })
+  ).toBeVisible();
 });
 
 test('loads plugin importing runtime federated module outside known module map', async ({

--- a/ui-tests/tests/plugin-playground.spec.ts
+++ b/ui-tests/tests/plugin-playground.spec.ts
@@ -4637,62 +4637,66 @@ test.describe('JS logs Ask AI action', () => {
       '.jp-chat-input-textfield[data-playground-test="ai-input"] textarea'
     );
 
-    await page.goto();
-    await ensureMockJupyterLiteAIChat(page);
+    try {
+      await page.goto();
+      await ensureMockJupyterLiteAIChat(page);
 
-    const hasJSLogsCommand = await page.evaluate((id: string) => {
-      return window.jupyterapp.commands.hasCommand(id);
-    }, JS_LOGS_OPEN_COMMAND);
-    test.skip(
-      !hasJSLogsCommand,
-      'jupyterlab-js-logs is required for JS log row actions.'
-    );
+      const hasJSLogsCommand = await page.evaluate((id: string) => {
+        return window.jupyterapp.commands.hasCommand(id);
+      }, JS_LOGS_OPEN_COMMAND);
+      test.skip(
+        !hasJSLogsCommand,
+        'jupyterlab-js-logs is required for JS log row actions.'
+      );
 
-    await page.evaluate((id: string) => {
-      const commands = window.jupyterapp.commands;
-      if (!commands.isToggled(id)) {
-        return commands.execute(id);
-      }
-      return undefined;
-    }, JS_LOGS_OPEN_COMMAND);
+      await page.evaluate((id: string) => {
+        const commands = window.jupyterapp.commands;
+        if (!commands.isToggled(id)) {
+          return commands.execute(id);
+        }
+        return undefined;
+      }, JS_LOGS_OPEN_COMMAND);
 
-    await page.evaluate((message: string) => {
-      console.warn(message);
-    }, warningMarker);
+      await page.evaluate((message: string) => {
+        console.warn(message);
+      }, warningMarker);
 
-    const warningRow = page.locator('.jp-OutputArea-child').filter({
-      hasText: warningMarker
-    });
-    await expect(warningRow).toHaveCount(1);
-    await expect(
-      warningRow.first().getByRole('button', {
+      const warningRow = page.locator('.jp-OutputArea-child').filter({
+        hasText: warningMarker
+      });
+      await expect(warningRow).toHaveCount(1);
+      await expect(
+        warningRow.first().getByRole('button', {
+          name: ASK_AI_LOG_ENTRY_ACTION_CAPTION
+        })
+      ).toHaveCount(0);
+
+      await page.evaluate((message: string) => {
+        console.error(message);
+      }, logMarker);
+
+      const logRow = page.locator('.jp-OutputArea-child').filter({
+        hasText: logMarker
+      });
+      await expect(logRow).toHaveCount(1);
+      const askAIButton = logRow.first().getByRole('button', {
         name: ASK_AI_LOG_ENTRY_ACTION_CAPTION
-      })
-    ).toHaveCount(0);
+      });
+      await expect(askAIButton).toBeVisible();
 
-    await page.evaluate((message: string) => {
-      console.error(message);
-    }, logMarker);
+      await askAIButton.click();
+      await expect(chatInput).toHaveValue(new RegExp(escapeRegExp(logMarker)));
 
-    const logRow = page.locator('.jp-OutputArea-child').filter({
-      hasText: logMarker
-    });
-    await expect(logRow).toHaveCount(1);
-    const askAIButton = logRow.first().getByRole('button', {
-      name: ASK_AI_LOG_ENTRY_ACTION_CAPTION
-    });
-    await expect(askAIButton).toBeVisible();
-
-    await askAIButton.click();
-    await expect(chatInput).toHaveValue(new RegExp(escapeRegExp(logMarker)));
-
-    await page.evaluate(() => {
-      document
-        .querySelector(
-          '.jp-chat-input-textfield[data-playground-test="ai-input"]'
-        )
-        ?.remove();
-    });
+      await page.evaluate(() => {
+        document
+          .querySelector(
+            '.jp-chat-input-textfield[data-playground-test="ai-input"]'
+          )
+          ?.remove();
+      });
+    } finally {
+      await page.unrouteAll({ behavior: 'ignoreErrors' });
+    }
   });
 });
 
@@ -4712,38 +4716,42 @@ test.describe('JS logs Ask AI action without provider setup', () => {
   }) => {
     const logMarker = `ask-ai-log-row-no-provider-${Date.now()}`;
 
-    await page.goto();
-    await ensureMockJupyterLiteAIChat(page);
+    try {
+      await page.goto();
+      await ensureMockJupyterLiteAIChat(page);
 
-    const hasJSLogsCommand = await page.evaluate((id: string) => {
-      return window.jupyterapp.commands.hasCommand(id);
-    }, JS_LOGS_OPEN_COMMAND);
-    test.skip(
-      !hasJSLogsCommand,
-      'jupyterlab-js-logs is required for JS log row actions.'
-    );
+      const hasJSLogsCommand = await page.evaluate((id: string) => {
+        return window.jupyterapp.commands.hasCommand(id);
+      }, JS_LOGS_OPEN_COMMAND);
+      test.skip(
+        !hasJSLogsCommand,
+        'jupyterlab-js-logs is required for JS log row actions.'
+      );
 
-    await page.evaluate((id: string) => {
-      const commands = window.jupyterapp.commands;
-      if (!commands.isToggled(id)) {
-        return commands.execute(id);
-      }
-      return undefined;
-    }, JS_LOGS_OPEN_COMMAND);
+      await page.evaluate((id: string) => {
+        const commands = window.jupyterapp.commands;
+        if (!commands.isToggled(id)) {
+          return commands.execute(id);
+        }
+        return undefined;
+      }, JS_LOGS_OPEN_COMMAND);
 
-    await page.evaluate((message: string) => {
-      console.error(message);
-    }, logMarker);
+      await page.evaluate((message: string) => {
+        console.error(message);
+      }, logMarker);
 
-    const logRow = page.locator('.jp-OutputArea-child').filter({
-      hasText: logMarker
-    });
-    await expect(logRow).toHaveCount(1);
-    await expect(
-      logRow.first().getByRole('button', {
-        name: ASK_AI_LOG_ENTRY_ACTION_CAPTION
-      })
-    ).toHaveCount(0);
+      const logRow = page.locator('.jp-OutputArea-child').filter({
+        hasText: logMarker
+      });
+      await expect(logRow).toHaveCount(1);
+      await expect(
+        logRow.first().getByRole('button', {
+          name: ASK_AI_LOG_ENTRY_ACTION_CAPTION
+        })
+      ).toHaveCount(0);
+    } finally {
+      await page.unrouteAll({ behavior: 'ignoreErrors' });
+    }
   });
 });
 


### PR DESCRIPTION
Closes #243 

Adds a sidebar panel that lists plugins loaded by Plugin Playground in the current session, including their source file, with a per-plugin deactivate control. Deactivation calls the plugin cleanup path, deregisters the plugin, and updates the live list. Includes a focused UI test for loading, listing, and deactivating a plugin.

https://github.com/user-attachments/assets/cff7c0a1-e8c9-4297-8d6e-ee27d046d7f1

