### PR TITLE
Add Hatch dev environment scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,17 +350,16 @@ You can repeat `fromURL` to open multiple files in one launch.
 
 ### Development install
 
-You will need NodeJS to build the extension package.
+You will need NodeJS to build the extension package. Hatch creates and manages
+the development virtual environment.
 
 ```bash
 # Clone the repo to your local environment
 # Change directory to the jupyterlab-plugin-playground directory
-# Install package in development mode
-pip install -e .
-# Link your development version of the extension with JupyterLab
-jupyter labextension develop . --overwrite
-# Rebuild extension Typescript source after making changes
-jlpm run build
+# One-time global install
+pip install hatch
+# Create the development environment and install the extension
+hatch run dev:install
 ```
 
 ### Pre-commit hooks
@@ -387,9 +386,9 @@ You can watch the source directory and run JupyterLab at the same time in differ
 
 ```bash
 # Watch the source directory in one terminal, automatically rebuilding when needed
-jlpm run watch
+hatch run dev:watch
 # Run JupyterLab in another terminal
-jupyter lab
+hatch run dev:lab
 ```
 
 With the watch command running, every saved change will immediately be built locally and available in your running JupyterLab. Refresh JupyterLab to load the change in your browser (you may need to wait several seconds for the extension to be rebuilt).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,22 @@ source = "nodejs"
 [tool.hatch.metadata.hooks.nodejs]
 fields = ["description", "authors", "urls"]
 
+[tool.hatch.envs.dev]
+dependencies = [
+    "jupyterlab>=4.0.0,<5.0.0",
+]
+skip-install = true
+
+[tool.hatch.envs.dev.scripts]
+install = [
+    "python -m pip install -e .",
+    "jupyter labextension develop . --overwrite",
+    "jlpm install",
+    "jlpm run build",
+]
+lab = "jupyter lab"
+watch = "jlpm run watch"
+
 [tool.hatch.build.targets.sdist]
 artifacts = [
     "jupyterlab_plugin_playground/labextension",


### PR DESCRIPTION
Closes #247 

Adds a Hatch-managed dev environment with scripts for contributor setup, launching JupyterLab, and watching extension builds. Updates the README development workflow to use `hatch run dev:install`, `hatch run dev:lab`, and `hatch run dev:watch`, reducing the manual setup commands while keeping the existing build/watch behavior intact.